### PR TITLE
fix: kill tolerates missing panes; adopt --team hard-errors on active run

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -395,9 +395,11 @@ herdr-agent-team adopt <pane-id> --name <worker> [--role <text>]
   Hook push, `msg`, `status`, inbox — identical to spawned workers.
   Immutability invariant: **immutable since generation**.
 - **Run targeting:** newest active run by default; `--run` explicit;
-  several active runs without `--run` = hard error listing candidates. No
-  active run → bootstrap an ad-hoc star run (name from `--team`, default
-  `adhoc`; god = current pane; cwd = adopted pane's cwd; reconstructed
+  several active runs without `--run` = hard error listing candidates. `--team`
+  names a new ad-hoc team: it is a hard error when any run is active (pass
+  `--run <dir>` or kill the active run instead), and it cannot be combined with
+  `--run`. No active run → bootstrap an ad-hoc star run (name from `--team`,
+  default `adhoc`; god = current pane; cwd = adopted pane's cwd; reconstructed
   minimal spec lives only in `run.toml`).
 - **Topology:** star-only. Adopting into a mesh run is a hard error
   (immutable peer tables would go stale — ADR-0009 defers the amendment

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -46,6 +46,11 @@ pub enum AdoptError {
     #[error("multiple active team runs found; pass --run with one of: {candidates}")]
     AmbiguousRuns { candidates: String },
 
+    #[error(
+        "--team names a new ad-hoc team, but run {run_dir} is active; pass --run <dir> or kill it"
+    )]
+    TeamConflictsWithActiveRun { run_dir: PathBuf },
+
     #[error("cannot adopt into ended run `{run_dir}`")]
     InactiveRun { run_dir: PathBuf },
 
@@ -121,7 +126,12 @@ pub fn adopt_command(args: &[String]) -> Result<(), AdoptError> {
     let state_dir = env::var_os("HERDR_PLUGIN_STATE_DIR")
         .map(|path| absolutize(Path::new(&path), &current_dir))
         .ok_or(AdoptError::MissingEnvironment("HERDR_PLUGIN_STATE_DIR"))?;
-    let target = select_run_target(arguments.run_dir.as_deref(), &state_dir, &current_dir)?;
+    let target = select_run_target(
+        arguments.run_dir.as_deref(),
+        arguments.team.as_deref(),
+        &state_dir,
+        &current_dir,
+    )?;
     let god_pane_id = match &target {
         RunTarget::Existing(run) => run.state.god_pane_id.clone(),
         RunTarget::Bootstrap => env::var("HERDR_PANE_ID")
@@ -234,14 +244,27 @@ fn arguments(detail: impl AsRef<str>) -> AdoptError {
 
 fn select_run_target(
     explicit_run: Option<&Path>,
+    team: Option<&str>,
     state_dir: &Path,
     current_dir: &Path,
 ) -> Result<RunTarget, AdoptError> {
+    if explicit_run.is_some() && team.is_some() {
+        return Err(arguments("--team and --run cannot be used together"));
+    }
     if let Some(run_dir) = explicit_run {
         let run = load_run(&absolutize(run_dir, current_dir))?;
         return choose_run(Some(run), Vec::new());
     }
-    choose_run(None, list_active_runs(state_dir)?)
+    let active_runs = list_active_runs(state_dir)?;
+    if team.is_some() {
+        if let Some(run) = active_runs.first() {
+            return Err(AdoptError::TeamConflictsWithActiveRun {
+                run_dir: run.dir.clone(),
+            });
+        }
+        return Ok(RunTarget::Bootstrap);
+    }
+    choose_run(None, active_runs)
 }
 
 fn choose_run(
@@ -670,6 +693,46 @@ mod tests {
         assert!(error.contains(&first.dir.display().to_string()));
         assert!(error.contains(&second.dir.display().to_string()));
         assert!(error.contains("pass --run"));
+    }
+
+    #[test]
+    fn team_is_rejected_when_an_active_run_exists() {
+        let temp = TempDir::new();
+        let active = existing_run(temp.path(), Topology::Star);
+
+        let error = select_run_target(None, Some("scratch"), temp.path(), temp.path())
+            .expect_err("--team must not silently select an active run")
+            .to_string();
+
+        assert_eq!(
+            error,
+            format!(
+                "--team names a new ad-hoc team, but run {} is active; pass --run <dir> or kill it",
+                active.dir.display()
+            )
+        );
+    }
+
+    #[test]
+    fn team_and_explicit_run_are_contradictory() {
+        let temp = TempDir::new();
+        let run = existing_run(temp.path(), Topology::Star);
+
+        let error = select_run_target(Some(&run.dir), Some("scratch"), temp.path(), temp.path())
+            .expect_err("--team and --run must be refused")
+            .to_string();
+
+        assert!(error.contains("--team and --run cannot be used together"));
+    }
+
+    #[test]
+    fn team_bootstraps_when_no_run_is_active() {
+        let temp = TempDir::new();
+
+        let target = select_run_target(None, Some("scratch"), temp.path(), temp.path())
+            .expect("--team should bootstrap only without an active run");
+
+        assert!(matches!(target, RunTarget::Bootstrap));
     }
 
     #[test]

--- a/src/status_kill.rs
+++ b/src/status_kill.rs
@@ -1,7 +1,7 @@
 //! Team status and teardown commands from `docs/spec.md` sections 6 and 12.
 
 use crate::herdr::{AgentInfo, HerdrClient, HerdrError};
-use crate::run::{load_run, mark_ended, save_run, RunBoard, RunError};
+use crate::run::{load_run, mark_ended, RunBoard, RunError};
 use crate::types::{RunLifecycle, WorkerLifecycle};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
@@ -55,9 +55,6 @@ pub enum StatusKillError {
 
     #[error("refusing to remove dirty worktree(s): {paths:?}")]
     DirtyWorktrees { paths: Vec<PathBuf> },
-
-    #[error("adopted worker '{worker}' has no recorded pane id")]
-    MissingAdoptedPane { worker: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -318,13 +315,13 @@ fn kill_run_with_backend(
 ) -> Result<(), StatusKillError> {
     let mut run = load_run(run_dir)?;
     if run.state.lifecycle == RunLifecycle::Ended {
-        if end_non_failed_owned_workers(&mut run) {
+        if end_worker_lifecycles(&mut run) {
             mark_ended(&mut run)?;
         }
         return Ok(());
     }
 
-    release_adopted_workers(&mut run, backend)?;
+    release_adopted_workers(&mut run, backend);
 
     let workspace_ids = run
         .state
@@ -334,7 +331,9 @@ fn kill_run_with_backend(
         .filter_map(|worker| worker.workspace_id.as_deref())
         .collect::<BTreeSet<_>>();
     for workspace_id in workspace_ids {
-        backend.workspace_close(workspace_id)?;
+        if let Err(error) = backend.workspace_close(workspace_id) {
+            log_teardown_note("workspace", workspace_id, &error);
+        }
     }
 
     let mut dirty_paths = Vec::new();
@@ -347,15 +346,21 @@ fn kill_run_with_backend(
             .filter_map(|worker| worker.worktree_path.as_deref())
             .collect::<BTreeSet<_>>();
         for path in worktree_paths {
-            if backend.worktree_is_dirty(path)? {
-                dirty_paths.push(path.to_path_buf());
-            } else {
-                backend.worktree_remove(path)?;
+            match backend.worktree_is_dirty(path) {
+                Ok(true) => dirty_paths.push(path.to_path_buf()),
+                Ok(false) => {
+                    if let Err(error) = backend.worktree_remove(path) {
+                        log_teardown_note("worktree", &path.display().to_string(), &error);
+                    }
+                }
+                Err(error) => {
+                    log_teardown_note("worktree", &path.display().to_string(), &error);
+                }
             }
         }
     }
 
-    end_non_failed_owned_workers(&mut run);
+    end_worker_lifecycles(&mut run);
     mark_ended(&mut run)?;
     if dirty_paths.is_empty() {
         Ok(())
@@ -364,54 +369,53 @@ fn kill_run_with_backend(
     }
 }
 
-fn release_adopted_workers(
-    run: &mut RunBoard,
-    backend: &impl TeardownBackend,
-) -> Result<(), StatusKillError> {
+fn release_adopted_workers(run: &mut RunBoard, backend: &impl TeardownBackend) {
     let pending = run
         .state
         .workers
         .iter()
         .filter(|(_, worker)| worker.adopted && worker.lifecycle != WorkerLifecycle::Released)
-        .map(|(name, worker)| {
-            let pane_id =
-                worker
-                    .pane_id
-                    .clone()
-                    .ok_or_else(|| StatusKillError::MissingAdoptedPane {
-                        worker: name.clone(),
-                    })?;
-            Ok((name.clone(), pane_id))
-        })
-        .collect::<Result<Vec<_>, StatusKillError>>()?;
+        .map(|(name, worker)| (name.clone(), worker.pane_id.clone()))
+        .collect::<Vec<_>>();
     let notice = release_notice(&run.state.spec.name);
 
     for (name, pane_id) in pending {
-        backend.pane_run(&pane_id, &notice)?;
+        match pane_id {
+            Some(pane_id) => {
+                if let Err(error) = backend.pane_run(&pane_id, &notice) {
+                    log_teardown_note("adopted pane", &pane_id, &error);
+                }
+            }
+            None => eprintln!(
+                "note: team kill found adopted worker '{name}' without a pane; releasing it"
+            ),
+        }
         run.state
             .workers
             .get_mut(&name)
             .expect("release candidates come from the same run state")
             .lifecycle = WorkerLifecycle::Released;
-        save_run(run)?;
     }
-    Ok(())
 }
 
 fn release_notice(team_name: &str) -> String {
     format!("team {team_name} ended; report protocol no longer applies")
 }
 
-fn end_non_failed_owned_workers(run: &mut RunBoard) -> bool {
+fn log_teardown_note(resource: &str, identifier: &str, error: &StatusKillError) {
+    eprintln!("note: team kill could not close {resource} '{identifier}' ({error}); continuing");
+}
+
+fn end_worker_lifecycles(run: &mut RunBoard) -> bool {
     let mut changed = false;
     for worker in run.state.workers.values_mut() {
-        if !worker.adopted
-            && !matches!(
-                worker.lifecycle,
-                WorkerLifecycle::Failed | WorkerLifecycle::Ended
-            )
-        {
-            worker.lifecycle = WorkerLifecycle::Ended;
+        let terminal = if worker.adopted {
+            WorkerLifecycle::Released
+        } else {
+            WorkerLifecycle::Ended
+        };
+        if worker.lifecycle != terminal {
+            worker.lifecycle = terminal;
             changed = true;
         }
     }
@@ -619,6 +623,8 @@ mod tests {
     #[derive(Default)]
     struct FakeTeardown {
         dirty: BTreeSet<PathBuf>,
+        unavailable_panes: BTreeSet<String>,
+        unavailable_workspaces: BTreeSet<String>,
         closed: RefCell<Vec<String>>,
         notices: RefCell<Vec<(String, String)>>,
         inspected: RefCell<Vec<PathBuf>>,
@@ -628,6 +634,9 @@ mod tests {
     impl TeardownBackend for FakeTeardown {
         fn workspace_close(&self, workspace_id: &str) -> Result<(), StatusKillError> {
             self.closed.borrow_mut().push(workspace_id.to_owned());
+            if self.unavailable_workspaces.contains(workspace_id) {
+                return Err(StatusKillError::Usage("workspace_not_found".to_owned()));
+            }
             Ok(())
         }
 
@@ -635,6 +644,9 @@ mod tests {
             self.notices
                 .borrow_mut()
                 .push((pane_id.to_owned(), input.to_owned()));
+            if self.unavailable_panes.contains(pane_id) {
+                return Err(StatusKillError::Usage("pane_not_found".to_owned()));
+            }
             Ok(())
         }
 
@@ -728,7 +740,7 @@ mod tests {
     }
 
     #[test]
-    fn kill_preserves_failed_workers_while_ending_every_other_lifecycle() {
+    fn kill_ends_failed_workers_with_every_other_owned_worker() {
         let temp = TempDir::new();
         let mut state = run_state(temp.path());
         state
@@ -749,7 +761,39 @@ mod tests {
         );
         assert_eq!(
             ended.state.workers["reviewer"].lifecycle,
-            WorkerLifecycle::Failed
+            WorkerLifecycle::Ended
+        );
+    }
+
+    #[test]
+    fn kill_with_a_closed_adopted_pane_releases_every_worker_and_ends_the_run() {
+        let temp = TempDir::new();
+        let mut state = run_state(temp.path());
+        let adopted = state.workers.get_mut("reviewer").expect("reviewer runtime");
+        adopted.adopted = true;
+        adopted.workspace_id = Some("workspace-borrowed".to_owned());
+        adopted.pane_id = Some("pane-closed".to_owned());
+        adopted.worktree_path = None;
+        let run = create_run(temp.path(), state).expect("create mixed-ownership run");
+        let backend = FakeTeardown {
+            unavailable_panes: BTreeSet::from(["pane-closed".to_owned()]),
+            unavailable_workspaces: BTreeSet::from(["workspace-builder".to_owned()]),
+            ..FakeTeardown::default()
+        };
+
+        kill_run_with_backend(&run.dir, false, &backend)
+            .expect("missing adopted resources must not abort kill");
+
+        assert_eq!(backend.closed.into_inner(), ["workspace-builder"]);
+        let ended = load_run(&run.dir).expect("load ended run");
+        assert_eq!(ended.state.lifecycle, RunLifecycle::Ended);
+        assert_eq!(
+            ended.state.workers["builder"].lifecycle,
+            WorkerLifecycle::Ended
+        );
+        assert_eq!(
+            ended.state.workers["reviewer"].lifecycle,
+            WorkerLifecycle::Released
         );
     }
 

--- a/src/status_kill.rs
+++ b/src/status_kill.rs
@@ -374,7 +374,13 @@ fn release_adopted_workers(run: &mut RunBoard, backend: &impl TeardownBackend) {
         .state
         .workers
         .iter()
-        .filter(|(_, worker)| worker.adopted && worker.lifecycle != WorkerLifecycle::Released)
+        .filter(|(_, worker)| {
+            worker.adopted
+                && !matches!(
+                    worker.lifecycle,
+                    WorkerLifecycle::Failed | WorkerLifecycle::Released
+                )
+        })
         .map(|(name, worker)| (name.clone(), worker.pane_id.clone()))
         .collect::<Vec<_>>();
     let notice = release_notice(&run.state.spec.name);
@@ -409,6 +415,9 @@ fn log_teardown_note(resource: &str, identifier: &str, error: &StatusKillError) 
 fn end_worker_lifecycles(run: &mut RunBoard) -> bool {
     let mut changed = false;
     for worker in run.state.workers.values_mut() {
+        if worker.lifecycle == WorkerLifecycle::Failed {
+            continue;
+        }
         let terminal = if worker.adopted {
             WorkerLifecycle::Released
         } else {
@@ -740,7 +749,7 @@ mod tests {
     }
 
     #[test]
-    fn kill_ends_failed_workers_with_every_other_owned_worker() {
+    fn kill_preserves_failed_workers_while_ending_every_other_lifecycle() {
         let temp = TempDir::new();
         let mut state = run_state(temp.path());
         state
@@ -761,8 +770,30 @@ mod tests {
         );
         assert_eq!(
             ended.state.workers["reviewer"].lifecycle,
-            WorkerLifecycle::Ended
+            WorkerLifecycle::Failed
         );
+    }
+
+    #[test]
+    fn kill_preserves_failed_adopted_workers_without_releasing_them() {
+        let temp = TempDir::new();
+        let mut state = run_state(temp.path());
+        let adopted = state.workers.get_mut("reviewer").expect("reviewer runtime");
+        adopted.adopted = true;
+        adopted.pane_id = Some("pane-failed".to_owned());
+        adopted.lifecycle = WorkerLifecycle::Failed;
+        let run = create_run(temp.path(), state).expect("create failed adopted run");
+        let backend = FakeTeardown::default();
+
+        kill_run_with_backend(&run.dir, false, &backend).expect("kill run");
+
+        let ended = load_run(&run.dir).expect("load ended run");
+        assert_eq!(ended.state.lifecycle, RunLifecycle::Ended);
+        assert_eq!(
+            ended.state.workers["reviewer"].lifecycle,
+            WorkerLifecycle::Failed
+        );
+        assert!(backend.notices.into_inner().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Makes team kill best-effort for absent adopted panes and workspaces, while persisting terminal worker/run state.

Makes --team reject active runs and reject --run as contradictory; documents the §12 targeting contract.

Tests: cargo fmt --check; cargo clippy --all-targets -- -D warnings; cargo test (102 passed).

Closes #11. Closes #3.