### PR TITLE
fix: hook transition injection + lifecycle reconciliation

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -128,18 +128,25 @@ Given a spec (file or shorthand):
 
 ## 5. Report flow (push, not poll)
 
-- Manifest event hook on agent status change (`on =
-  "pane.agent_status_changed"` — verified `[live 2026-07-14]` and against the
-  upstream event allowlist `[source 2026-07-15]`, spec §9).
+- Manifest hooks reconcile `pane.agent_status_changed`, `pane.moved`,
+  `pane.exited`, `pane.closed`, `workspace.closed`, `worktree.removed`, and
+  `pane.agent_detected` against `run.toml` (dot-form manifest names; JSON uses
+  underscore form). Reconciliation persists atomically: move migrates the
+  public pane ID, exit/close orphan the worker, workspace/worktree removal
+  ends the affected run, and agent detection binds the optional identity.
 - Hook receives `HERDR_PLUGIN_EVENT_JSON`; plugin matches the pane against
   active runs (ignores non-team panes — cheap exit).
-- On a team worker flipping `blocked` or `done`:
+- On a team worker flipping `blocked`, or completing as `working -> idle|done`:
   1. Append an entry to `<run>/inbox/events.jsonl` (durable).
   2. Inject **one line** into the god's pane:
      `[team <name>] <worker> is <status> — report: <abs path>` — pointer only,
      never report content (keeps god context lean).
 - Workers are briefed to write their actual report to
   `<run>/inbox/<worker>.md` *before* going idle/done.
+- Pointer injection is an at-most-once attention notification, not proof of
+  turn completion: upstream can report background-wait panes as `idle`/`done`
+  while work remains (`ogulcancelik/herdr#1217`). The durable report and its
+  sentinel remain the completion truth.
 
 ## 6. `team status` / `team kill`
 
@@ -245,6 +252,11 @@ reference detail lives in `docs/research/` (ADR-0010 §3), not here.
 - **Event payload may add optional fields** `[source 2026-07-15]`: `agent`
   is omitted when none; `title`, `display_agent`, `state_labels` may appear.
   Parsers must tolerate unknown/absent optional fields.
+- **Lifecycle reconciliation wins over waits** `[source 2026-07-15]`:
+  `pane.moved` carries `previous_pane_id` and a replacement `PaneInfo`;
+  `pane.exited`/`pane.closed`, `workspace.closed`, and `worktree.removed` are
+  hookable lifecycle truth. Do not trust a hanging status wait when a pane
+  vanishes (`ogulcancelik/herdr#1439`).
 - **`done` is an attention state** `[source 2026-07-15]`: derived from
   internal `Idle` when the pane is unseen; the detector knows only
   idle/working/blocked/unknown. Explains why `agent wait` rejects `done`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -132,8 +132,10 @@ Given a spec (file or shorthand):
   `pane.exited`, `pane.closed`, `workspace.closed`, `worktree.removed`, and
   `pane.agent_detected` against `run.toml` (dot-form manifest names; JSON uses
   underscore form). Reconciliation persists atomically: move migrates the
-  public pane ID, exit/close orphan the worker, workspace/worktree removal
-  ends the affected run, and agent detection binds the optional identity.
+  public pane ID (including the god pane), exit/close orphan the worker, and
+  workspace/worktree removal ends only the affected worker allocation. The run
+  ends when its god allocation vanishes or no non-terminal workers remain;
+  agent detection binds the optional identity.
 - Hook receives `HERDR_PLUGIN_EVENT_JSON`; plugin matches the pane against
   active runs (ignores non-team panes — cheap exit).
 - On a team worker flipping `blocked`, or completing as `working -> idle|done`:

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -32,3 +32,27 @@ command = ["target/release/herdr-agent-team", "kill"]
 [[events]]
 on = "pane.agent_status_changed"
 command = ["target/release/herdr-agent-team", "on-agent-status"]
+
+[[events]]
+on = "pane.moved"
+command = ["target/release/herdr-agent-team", "on-agent-status"]
+
+[[events]]
+on = "pane.exited"
+command = ["target/release/herdr-agent-team", "on-agent-status"]
+
+[[events]]
+on = "pane.closed"
+command = ["target/release/herdr-agent-team", "on-agent-status"]
+
+[[events]]
+on = "workspace.closed"
+command = ["target/release/herdr-agent-team", "on-agent-status"]
+
+[[events]]
+on = "worktree.removed"
+command = ["target/release/herdr-agent-team", "on-agent-status"]
+
+[[events]]
+on = "pane.agent_detected"
+command = ["target/release/herdr-agent-team", "on-agent-status"]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -2,8 +2,8 @@
 
 use crate::herdr::HerdrClient;
 use crate::msg;
+use crate::reconcile::{reconcile, IncomingEvent, ReconciliationAction};
 use crate::run;
-use serde::Deserialize;
 use serde_json::{json, Value};
 use std::fmt::Display;
 use std::path::{Path, PathBuf};
@@ -14,10 +14,10 @@ pub enum HookError {
     #[error("required environment variable {0} is not set or is not valid Unicode")]
     MissingEnvironment(&'static str),
 
-    #[error("invalid agent-status event JSON: {0}")]
+    #[error("invalid hook event JSON: {0}")]
     InvalidEvent(#[from] serde_json::Error),
 
-    #[error("expected {field} to be `pane_agent_status_changed`, received `{actual}`")]
+    #[error("unsupported or malformed hook event `{actual}`")]
     UnexpectedEvent { field: &'static str, actual: String },
 
     #[error("failed to resolve an absolute report path: {0}")]
@@ -38,48 +38,10 @@ pub enum HookError {
     Herdr(#[from] crate::herdr::HerdrError),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct EventEnvelope {
     event: String,
-    data: AgentStatusEvent,
-}
-
-#[derive(Debug, Deserialize)]
-struct AgentStatusEvent {
-    #[serde(rename = "type")]
-    kind: String,
-    pane_id: String,
-    agent_status: AgentStatus,
-}
-
-#[derive(Debug, Clone, Copy, Deserialize)]
-#[serde(rename_all = "lowercase")]
-enum AgentStatus {
-    Idle,
-    Working,
-    Blocked,
-    Done,
-    Unknown,
-}
-
-impl AgentStatus {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Idle => "idle",
-            Self::Working => "working",
-            Self::Blocked => "blocked",
-            Self::Done => "done",
-            Self::Unknown => "unknown",
-        }
-    }
-
-    fn sends_pointer(self) -> bool {
-        matches!(self, Self::Blocked | Self::Done)
-    }
-
-    fn drains_outbox(self) -> bool {
-        matches!(self, Self::Idle | Self::Done)
-    }
+    data: Value,
 }
 
 pub fn hook_command() -> Result<(), HookError> {
@@ -97,39 +59,127 @@ pub fn on_agent_status(
     herdr: &HerdrClient,
 ) -> Result<(), HookError> {
     let raw_event: Value = serde_json::from_str(event_json)?;
-    let event: EventEnvelope = serde_json::from_value(raw_event.clone())?;
-    require_status_event("event", &event.event)?;
-    require_status_event("data.type", &event.data.kind)?;
+    let event = parse_event(serde_json::from_value(raw_event.clone())?)?;
 
-    let Some(matched) = run::match_pane(state_dir, &event.data.pane_id)? else {
-        return Ok(());
-    };
+    for mut run in run::list_active_runs(state_dir)? {
+        let metadata = run::load_hook_metadata(&run.dir)?;
+        let reconciliation = reconcile(&event, run.state.clone(), metadata);
+        if reconciliation.actions.is_empty() {
+            continue;
+        }
+        run.state = reconciliation.state;
+        run::save_run_with_hook(&run, &reconciliation.metadata)?;
+        run::append_event(&run.dir, &raw_event)?;
 
-    run::append_event(&matched.run.dir, &raw_event)?;
-    if event.data.agent_status.drains_outbox() {
-        drain_outbox(&matched.run.dir, &matched.worker_name, |text| {
-            msg::deliver_queued_message(&matched.run, &matched.worker_name, text, herdr)
-        })?;
+        for action in reconciliation.actions {
+            match action {
+                ReconciliationAction::DrainOutbox { worker_name } => {
+                    drain_outbox(&run.dir, &worker_name, |text| {
+                        msg::deliver_queued_message(&run, &worker_name, text, herdr)
+                    })?;
+                }
+                ReconciliationAction::InjectPointer {
+                    worker_name,
+                    status,
+                } => {
+                    inject_pointer(&run, &worker_name, &status, herdr)?;
+                }
+                ReconciliationAction::RecordEvent
+                | ReconciliationAction::TrackAgentStatus { .. }
+                | ReconciliationAction::MigratePane { .. }
+                | ReconciliationAction::MarkWorkerOrphaned { .. }
+                | ReconciliationAction::BindAgentIdentity { .. }
+                | ReconciliationAction::EndRun => {}
+            }
+        }
     }
-    if !event.data.agent_status.sends_pointer() {
-        return Ok(());
-    }
+    Ok(())
+}
 
-    let report_path = absolute_path(
-        &matched
-            .run
-            .dir
-            .join("inbox")
-            .join(format!("{}.md", matched.worker_name)),
-    )?;
+fn parse_event(envelope: EventEnvelope) -> Result<IncomingEvent, HookError> {
+    let required = |field: &'static str| required_string(&envelope.data, field, &envelope.event);
+    match envelope.event.as_str() {
+        "pane_agent_status_changed" => Ok(IncomingEvent::AgentStatusChanged {
+            pane_id: required("pane_id")?,
+            status: required("agent_status")?,
+        }),
+        "pane_moved" => Ok(IncomingEvent::PaneMoved {
+            previous_pane_id: required("previous_pane_id")?,
+            pane_id: envelope
+                .data
+                .get("pane")
+                .and_then(|pane| pane.get("pane_id"))
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .ok_or_else(|| HookError::UnexpectedEvent {
+                    field: "data.pane.pane_id",
+                    actual: envelope.event.clone(),
+                })?,
+            workspace_id: envelope
+                .data
+                .get("pane")
+                .and_then(|pane| pane.get("workspace_id"))
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+        }),
+        "pane_exited" => Ok(IncomingEvent::PaneExited {
+            pane_id: required("pane_id")?,
+        }),
+        "pane_closed" => Ok(IncomingEvent::PaneClosed {
+            pane_id: required("pane_id")?,
+        }),
+        "workspace_closed" => Ok(IncomingEvent::WorkspaceClosed {
+            workspace_id: required("workspace_id")?,
+        }),
+        "worktree_removed" => Ok(IncomingEvent::WorktreeRemoved {
+            workspace_id: required("workspace_id")?,
+            worktree_path: envelope
+                .data
+                .get("worktree")
+                .and_then(|worktree| worktree.get("path"))
+                .and_then(Value::as_str)
+                .map(PathBuf::from),
+        }),
+        "pane_agent_detected" => Ok(IncomingEvent::PaneAgentDetected {
+            pane_id: required("pane_id")?,
+            agent: envelope
+                .data
+                .get("agent")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+        }),
+        _ => Err(HookError::UnexpectedEvent {
+            field: "event",
+            actual: envelope.event,
+        }),
+    }
+}
+
+fn required_string(data: &Value, field: &'static str, event: &str) -> Result<String, HookError> {
+    data.get(field)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| HookError::UnexpectedEvent {
+            field,
+            actual: event.to_owned(),
+        })
+}
+
+fn inject_pointer(
+    run: &run::RunBoard,
+    worker_name: &str,
+    status: &str,
+    herdr: &HerdrClient,
+) -> Result<(), HookError> {
+    let report_path = absolute_path(&run.dir.join("inbox").join(format!("{worker_name}.md")))?;
     let pointer = format!(
         "[team {}] {} is {} — report: {}",
-        matched.run.state.spec.name,
-        matched.worker_name,
-        event.data.agent_status.as_str(),
+        run.state.spec.name,
+        worker_name,
+        status,
         report_path.display()
     );
-    herdr.pane_run(&matched.run.state.god_pane_id, &pointer)?;
+    herdr.pane_run(&run.state.god_pane_id, &pointer)?;
     Ok(())
 }
 
@@ -240,17 +290,6 @@ fn append_delivery_event(
     }
     run::append_event(run_dir, &event)?;
     Ok(())
-}
-
-fn require_status_event(field: &'static str, actual: &str) -> Result<(), HookError> {
-    if actual == "pane_agent_status_changed" {
-        Ok(())
-    } else {
-        Err(HookError::UnexpectedEvent {
-            field,
-            actual: actual.to_owned(),
-        })
-    }
 }
 
 fn absolute_path(path: &Path) -> Result<PathBuf, std::io::Error> {
@@ -415,15 +454,6 @@ mod tests {
     }
 
     #[test]
-    fn only_idle_and_done_statuses_drain_outboxes() {
-        assert!(AgentStatus::Idle.drains_outbox());
-        assert!(AgentStatus::Done.drains_outbox());
-        assert!(!AgentStatus::Working.drains_outbox());
-        assert!(!AgentStatus::Blocked.drains_outbox());
-        assert!(!AgentStatus::Unknown.drains_outbox());
-    }
-
-    #[test]
     fn drain_delivers_exact_content_in_sequence_order_then_removes_and_audits() {
         let temp = TempDir::new();
         let run = fixture_run(temp.path(), "worker-pane");
@@ -492,6 +522,12 @@ mod tests {
         let fake = FakeHerdr::new(&temp);
 
         on_agent_status(
+            &event("worker-pane", "working").to_string(),
+            temp.path(),
+            &fake.client,
+        )
+        .expect("record working state");
+        on_agent_status(
             &event("worker-pane", "done").to_string(),
             temp.path(),
             &fake.client,
@@ -533,7 +569,12 @@ mod tests {
                 .iter()
                 .map(|event| event["event"].as_str().unwrap())
                 .collect::<Vec<_>>(),
-            ["pane_agent_status_changed", "delivered", "delivered"]
+            [
+                "pane_agent_status_changed",
+                "pane_agent_status_changed",
+                "delivered",
+                "delivered"
+            ]
         );
     }
 
@@ -637,13 +678,6 @@ mod tests {
                     "[team alpha] builder is blocked — report: {}",
                     report_path.display()
                 ),
-                "pane",
-                "run",
-                "god-pane",
-                &format!(
-                    "[team alpha] builder is done — report: {}",
-                    report_path.display()
-                ),
             ]
         );
     }
@@ -662,5 +696,189 @@ mod tests {
             error,
             HookError::UnexpectedEvent { field: "event", .. }
         ));
+    }
+
+    #[test]
+    fn seen_completion_fixture_injects_once_and_repeated_idle_does_not() {
+        let temp = TempDir::new();
+        let run = fixture_run(temp.path(), "worker-pane");
+        let fake = FakeHerdr::new(&temp);
+
+        for status in ["working", "idle", "idle"] {
+            on_agent_status(
+                &event("worker-pane", status).to_string(),
+                temp.path(),
+                &fake.client,
+            )
+            .expect("process completion fixture");
+        }
+
+        let pointer = format!(
+            "[team alpha] builder is idle — report: {}",
+            run.dir.join("inbox/builder.md").display()
+        );
+        assert_eq!(
+            fake.argv()
+                .iter()
+                .filter(|argument| *argument == &pointer)
+                .count(),
+            1
+        );
+        assert_eq!(
+            run::load_hook_metadata(&run.dir)
+                .expect("load hook metadata")
+                .worker_status
+                .get("builder"),
+            Some(&"idle".to_owned())
+        );
+    }
+
+    #[test]
+    fn unseen_done_fixture_injects_once() {
+        let temp = TempDir::new();
+        let run = fixture_run(temp.path(), "worker-pane");
+        let fake = FakeHerdr::new(&temp);
+
+        on_agent_status(
+            &event("worker-pane", "working").to_string(),
+            temp.path(),
+            &fake.client,
+        )
+        .expect("record working state");
+        for _ in 0..2 {
+            on_agent_status(
+                &event("worker-pane", "done").to_string(),
+                temp.path(),
+                &fake.client,
+            )
+            .expect("process unseen completion fixture");
+        }
+
+        let pointer = format!(
+            "[team alpha] builder is done — report: {}",
+            run.dir.join("inbox/builder.md").display()
+        );
+        assert_eq!(
+            fake.argv()
+                .iter()
+                .filter(|argument| *argument == &pointer)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn pane_moved_fixture_persists_identifier_migration() {
+        let temp = TempDir::new();
+        let run = fixture_run(temp.path(), "old-pane");
+        let fake = FakeHerdr::new(&temp);
+        let fixture = json!({"event":"pane_moved","data":{"type":"pane_moved","previous_pane_id":"old-pane","previous_workspace_id":"worker-workspace","previous_tab_id":"old-tab","pane":{"pane_id":"new-pane","workspace_id":"new-workspace"}}});
+
+        on_agent_status(&fixture.to_string(), temp.path(), &fake.client).expect("migrate pane");
+
+        let persisted = run::load_run(&run.dir).expect("load migrated run");
+        assert_eq!(
+            persisted.state.workers["builder"].pane_id.as_deref(),
+            Some("new-pane")
+        );
+        assert_eq!(
+            persisted.state.workers["builder"].workspace_id.as_deref(),
+            Some("new-workspace")
+        );
+    }
+
+    #[test]
+    fn pane_exited_fixture_marks_worker_orphaned() {
+        let temp = TempDir::new();
+        let run = fixture_run(temp.path(), "worker-pane");
+        let fake = FakeHerdr::new(&temp);
+        let fixture = json!({"event":"pane_exited","data":{"type":"pane_exited","pane_id":"worker-pane","workspace_id":"worker-workspace"}});
+
+        on_agent_status(&fixture.to_string(), temp.path(), &fake.client).expect("reconcile exit");
+
+        assert_eq!(
+            run::load_run(&run.dir)
+                .expect("load exited run")
+                .state
+                .workers["builder"]
+                .lifecycle,
+            WorkerLifecycle::Orphaned
+        );
+    }
+
+    #[test]
+    fn pane_closed_fixture_marks_worker_orphaned() {
+        let temp = TempDir::new();
+        let run = fixture_run(temp.path(), "worker-pane");
+        let fake = FakeHerdr::new(&temp);
+        let fixture = json!({"event":"pane_closed","data":{"type":"pane_closed","pane_id":"worker-pane","workspace_id":"worker-workspace"}});
+
+        on_agent_status(&fixture.to_string(), temp.path(), &fake.client).expect("reconcile close");
+
+        assert_eq!(
+            run::load_run(&run.dir)
+                .expect("load closed run")
+                .state
+                .workers["builder"]
+                .lifecycle,
+            WorkerLifecycle::Orphaned
+        );
+    }
+
+    #[test]
+    fn workspace_closed_fixture_ends_run() {
+        let temp = TempDir::new();
+        let run = fixture_run(temp.path(), "worker-pane");
+        let fake = FakeHerdr::new(&temp);
+        let fixture = json!({"event":"workspace_closed","data":{"type":"workspace_closed","workspace_id":"worker-workspace"}});
+
+        on_agent_status(&fixture.to_string(), temp.path(), &fake.client)
+            .expect("reconcile workspace close");
+
+        assert_eq!(
+            run::load_run(&run.dir)
+                .expect("load ended run")
+                .state
+                .lifecycle,
+            RunLifecycle::Ended
+        );
+    }
+
+    #[test]
+    fn worktree_removed_fixture_ends_run() {
+        let temp = TempDir::new();
+        let run = fixture_run(temp.path(), "worker-pane");
+        let fake = FakeHerdr::new(&temp);
+        let fixture = json!({"event":"worktree_removed","data":{"type":"worktree_removed","workspace_id":"worker-workspace","worktree":{"path":"/tmp/worktree"},"forced":false}});
+
+        on_agent_status(&fixture.to_string(), temp.path(), &fake.client)
+            .expect("reconcile worktree removal");
+
+        assert_eq!(
+            run::load_run(&run.dir)
+                .expect("load ended run")
+                .state
+                .lifecycle,
+            RunLifecycle::Ended
+        );
+    }
+
+    #[test]
+    fn pane_agent_detected_fixture_persists_optional_identity() {
+        let temp = TempDir::new();
+        let run = fixture_run(temp.path(), "worker-pane");
+        let fake = FakeHerdr::new(&temp);
+        let fixture = json!({"event":"pane_agent_detected","data":{"type":"pane_agent_detected","pane_id":"worker-pane","workspace_id":"worker-workspace","agent":"codex"}});
+
+        on_agent_status(&fixture.to_string(), temp.path(), &fake.client)
+            .expect("bind agent identity");
+
+        assert_eq!(
+            run::load_hook_metadata(&run.dir)
+                .expect("load hook metadata")
+                .worker_agent_identity
+                .get("builder"),
+            Some(&"codex".to_owned())
+        );
     }
 }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -87,7 +87,9 @@ pub fn on_agent_status(
                 ReconciliationAction::RecordEvent
                 | ReconciliationAction::TrackAgentStatus { .. }
                 | ReconciliationAction::MigratePane { .. }
+                | ReconciliationAction::MigrateGodPane
                 | ReconciliationAction::MarkWorkerOrphaned { .. }
+                | ReconciliationAction::EndWorker { .. }
                 | ReconciliationAction::BindAgentIdentity { .. }
                 | ReconciliationAction::EndRun => {}
             }
@@ -841,6 +843,60 @@ mod tests {
                 .state
                 .lifecycle,
             RunLifecycle::Ended
+        );
+    }
+
+    #[test]
+    fn one_worker_workspace_close_ends_only_that_workers_allocation() {
+        let temp = TempDir::new();
+        let mut run = fixture_run(temp.path(), "worker-pane");
+        run.state.workers.insert(
+            "reviewer".to_owned(),
+            WorkerRunState {
+                workspace_id: Some("reviewer-workspace".to_owned()),
+                pane_id: Some("reviewer-pane".to_owned()),
+                agent_id: Some("agent-2".to_owned()),
+                worktree_path: None,
+                adopted: false,
+                lifecycle: WorkerLifecycle::Running,
+            },
+        );
+        run::save_run(&run).expect("persist two-worker fixture");
+        let fake = FakeHerdr::new(&temp);
+        let fixture = json!({"event":"workspace_closed","data":{"type":"workspace_closed","workspace_id":"worker-workspace"}});
+
+        on_agent_status(&fixture.to_string(), temp.path(), &fake.client)
+            .expect("reconcile one worker workspace close");
+
+        let persisted = run::load_run(&run.dir).expect("load reconciled run");
+        assert_eq!(persisted.state.lifecycle, RunLifecycle::Active);
+        assert_eq!(
+            persisted.state.workers["builder"].lifecycle,
+            WorkerLifecycle::Ended
+        );
+        assert_eq!(
+            persisted.state.workers["reviewer"].lifecycle,
+            WorkerLifecycle::Running
+        );
+    }
+
+    #[test]
+    fn god_pane_moved_fixture_persists_god_pane_id() {
+        let temp = TempDir::new();
+        let run = fixture_run(temp.path(), "worker-pane");
+        let fake = FakeHerdr::new(&temp);
+        let fixture = json!({"event":"pane_moved","data":{"type":"pane_moved","previous_pane_id":"god-pane","previous_workspace_id":"god-workspace","previous_tab_id":"god-tab","pane":{"pane_id":"new-god-pane","workspace_id":"new-god-workspace"}}});
+
+        on_agent_status(&fixture.to_string(), temp.path(), &fake.client).expect("migrate god pane");
+
+        let persisted = run::load_run(&run.dir).expect("load migrated run");
+        assert_eq!(persisted.state.god_pane_id, "new-god-pane");
+        assert_eq!(
+            run::load_hook_metadata(&run.dir)
+                .expect("load hook metadata")
+                .god_workspace_id
+                .as_deref(),
+            Some("new-god-workspace")
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ pub mod herdr;
 pub mod hook;
 pub mod launcher;
 pub mod msg;
+pub mod reconcile;
 pub mod run;
 pub mod spawn;
 pub mod spec;

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -1,0 +1,342 @@
+//! Pure hook event reconciliation for the run-board.
+
+use crate::types::{RunLifecycle, RunState, WorkerLifecycle};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IncomingEvent {
+    AgentStatusChanged {
+        pane_id: String,
+        status: String,
+    },
+    PaneMoved {
+        previous_pane_id: String,
+        pane_id: String,
+        workspace_id: Option<String>,
+    },
+    PaneExited {
+        pane_id: String,
+    },
+    PaneClosed {
+        pane_id: String,
+    },
+    WorkspaceClosed {
+        workspace_id: String,
+    },
+    WorktreeRemoved {
+        workspace_id: String,
+        worktree_path: Option<PathBuf>,
+    },
+    PaneAgentDetected {
+        pane_id: String,
+        agent: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReconciliationAction {
+    RecordEvent,
+    TrackAgentStatus { worker_name: String, status: String },
+    InjectPointer { worker_name: String, status: String },
+    DrainOutbox { worker_name: String },
+    MigratePane { worker_name: String },
+    MarkWorkerOrphaned { worker_name: String },
+    BindAgentIdentity { worker_name: String },
+    EndRun,
+}
+
+/// Additive hook-owned metadata persisted as `[hook]` in `run.toml`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HookMetadata {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub worker_status: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub worker_agent_identity: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Reconciliation {
+    pub state: RunState,
+    pub metadata: HookMetadata,
+    pub actions: Vec<ReconciliationAction>,
+}
+
+/// Reconcile one event against one active run without I/O or process spawning.
+pub fn reconcile(
+    event: &IncomingEvent,
+    mut state: RunState,
+    mut metadata: HookMetadata,
+) -> Reconciliation {
+    let mut actions = Vec::new();
+    let worker_name = match event {
+        IncomingEvent::AgentStatusChanged { pane_id, .. }
+        | IncomingEvent::PaneExited { pane_id }
+        | IncomingEvent::PaneClosed { pane_id }
+        | IncomingEvent::PaneAgentDetected { pane_id, .. } => worker_for_pane(&state, pane_id),
+        IncomingEvent::PaneMoved {
+            previous_pane_id, ..
+        } => worker_for_pane(&state, previous_pane_id),
+        IncomingEvent::WorkspaceClosed { workspace_id } => {
+            worker_for_workspace(&state, workspace_id)
+        }
+        IncomingEvent::WorktreeRemoved {
+            workspace_id,
+            worktree_path,
+        } => worker_for_workspace(&state, workspace_id).or_else(|| {
+            worktree_path
+                .as_ref()
+                .and_then(|path| worker_for_worktree(&state, path))
+        }),
+    };
+
+    let Some(worker_name) = worker_name else {
+        return Reconciliation {
+            state,
+            metadata,
+            actions,
+        };
+    };
+    actions.push(ReconciliationAction::RecordEvent);
+
+    match event {
+        IncomingEvent::AgentStatusChanged { status, .. } => {
+            let previous = metadata
+                .worker_status
+                .insert(worker_name.clone(), status.clone());
+            actions.push(ReconciliationAction::TrackAgentStatus {
+                worker_name: worker_name.clone(),
+                status: status.clone(),
+            });
+            if status == "idle" || status == "done" {
+                actions.push(ReconciliationAction::DrainOutbox {
+                    worker_name: worker_name.clone(),
+                });
+            }
+            if status == "blocked"
+                || (status == "idle" && previous.as_deref() == Some("working"))
+                || (status == "done" && previous.as_deref() == Some("working"))
+            {
+                actions.push(ReconciliationAction::InjectPointer {
+                    worker_name,
+                    status: status.clone(),
+                });
+            }
+        }
+        IncomingEvent::PaneMoved {
+            pane_id,
+            workspace_id,
+            ..
+        } => {
+            let worker = state
+                .workers
+                .get_mut(&worker_name)
+                .expect("matched worker exists");
+            worker.pane_id = Some(pane_id.clone());
+            if let Some(workspace_id) = workspace_id {
+                worker.workspace_id = Some(workspace_id.clone());
+            }
+            actions.push(ReconciliationAction::MigratePane { worker_name });
+        }
+        IncomingEvent::PaneExited { .. } | IncomingEvent::PaneClosed { .. } => {
+            state
+                .workers
+                .get_mut(&worker_name)
+                .expect("matched worker exists")
+                .lifecycle = WorkerLifecycle::Orphaned;
+            actions.push(ReconciliationAction::MarkWorkerOrphaned { worker_name });
+        }
+        IncomingEvent::WorkspaceClosed { .. } | IncomingEvent::WorktreeRemoved { .. } => {
+            state.lifecycle = RunLifecycle::Ended;
+            actions.push(ReconciliationAction::EndRun);
+        }
+        IncomingEvent::PaneAgentDetected { agent, .. } => {
+            if let Some(agent) = agent {
+                metadata
+                    .worker_agent_identity
+                    .insert(worker_name.clone(), agent.clone());
+                actions.push(ReconciliationAction::BindAgentIdentity { worker_name });
+            }
+        }
+    }
+
+    Reconciliation {
+        state,
+        metadata,
+        actions,
+    }
+}
+
+fn worker_for_pane(state: &RunState, pane_id: &str) -> Option<String> {
+    state.workers.iter().find_map(|(name, worker)| {
+        (worker.pane_id.as_deref() == Some(pane_id)).then(|| name.clone())
+    })
+}
+
+fn worker_for_workspace(state: &RunState, workspace_id: &str) -> Option<String> {
+    state.workers.iter().find_map(|(name, worker)| {
+        (worker.workspace_id.as_deref() == Some(workspace_id)).then(|| name.clone())
+    })
+}
+
+fn worker_for_worktree(state: &RunState, worktree_path: &std::path::Path) -> Option<String> {
+    state.workers.iter().find_map(|(name, worker)| {
+        (worker.worktree_path.as_deref() == Some(worktree_path)).then(|| name.clone())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{GodSpec, TeamSpec, Topology, WorkerRunState, WorkerSpec};
+    use std::collections::BTreeMap;
+
+    fn state() -> RunState {
+        RunState {
+            spec: TeamSpec {
+                name: "alpha".to_owned(),
+                topology: Topology::Star,
+                cwd: PathBuf::from("/tmp"),
+                setup: vec![],
+                god: GodSpec {
+                    target: "self".to_owned(),
+                },
+                workers: vec![WorkerSpec {
+                    name: "builder".to_owned(),
+                    agent: "codex".to_owned(),
+                    role: "build".to_owned(),
+                    worktree: true,
+                    branch: None,
+                    brief: PathBuf::from("brief.md"),
+                }],
+            },
+            god_pane_id: "god".to_owned(),
+            lifecycle: RunLifecycle::Active,
+            workers: BTreeMap::from([(
+                "builder".to_owned(),
+                WorkerRunState {
+                    workspace_id: Some("workspace-1".to_owned()),
+                    pane_id: Some("pane-1".to_owned()),
+                    agent_id: None,
+                    worktree_path: Some(PathBuf::from("/tmp/worktree")),
+                    adopted: false,
+                    lifecycle: WorkerLifecycle::Running,
+                },
+            )]),
+        }
+    }
+
+    #[test]
+    fn completion_pointers_are_at_most_once_per_completion_transition() {
+        let working = reconcile(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "working".into(),
+            },
+            state(),
+            HookMetadata::default(),
+        );
+        let idle = reconcile(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "idle".into(),
+            },
+            working.state,
+            working.metadata,
+        );
+        let repeated_idle = reconcile(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "idle".into(),
+            },
+            idle.state.clone(),
+            idle.metadata.clone(),
+        );
+        let unseen_working = reconcile(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "working".into(),
+            },
+            state(),
+            HookMetadata::default(),
+        );
+        let unseen_done = reconcile(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "done".into(),
+            },
+            unseen_working.state,
+            unseen_working.metadata,
+        );
+
+        assert!(idle.actions.iter().any(|action| matches!(action, ReconciliationAction::InjectPointer { status, .. } if status == "idle")));
+        assert!(!repeated_idle
+            .actions
+            .iter()
+            .any(|action| matches!(action, ReconciliationAction::InjectPointer { .. })));
+        assert!(unseen_done.actions.iter().any(|action| matches!(action, ReconciliationAction::InjectPointer { status, .. } if status == "done")));
+    }
+
+    #[test]
+    fn lifecycle_events_update_the_run_board() {
+        let moved = reconcile(
+            &IncomingEvent::PaneMoved {
+                previous_pane_id: "pane-1".into(),
+                pane_id: "pane-2".into(),
+                workspace_id: Some("workspace-2".into()),
+            },
+            state(),
+            HookMetadata::default(),
+        );
+        assert_eq!(
+            moved.state.workers["builder"].pane_id.as_deref(),
+            Some("pane-2")
+        );
+        assert_eq!(
+            moved.state.workers["builder"].workspace_id.as_deref(),
+            Some("workspace-2")
+        );
+        for event in [
+            IncomingEvent::PaneExited {
+                pane_id: "pane-1".into(),
+            },
+            IncomingEvent::PaneClosed {
+                pane_id: "pane-1".into(),
+            },
+        ] {
+            assert_eq!(
+                reconcile(&event, state(), HookMetadata::default())
+                    .state
+                    .workers["builder"]
+                    .lifecycle,
+                WorkerLifecycle::Orphaned
+            );
+        }
+        assert_eq!(
+            reconcile(
+                &IncomingEvent::WorkspaceClosed {
+                    workspace_id: "workspace-1".into()
+                },
+                state(),
+                HookMetadata::default()
+            )
+            .state
+            .lifecycle,
+            RunLifecycle::Ended
+        );
+        assert_eq!(
+            reconcile(
+                &IncomingEvent::WorktreeRemoved {
+                    workspace_id: "other".into(),
+                    worktree_path: Some(PathBuf::from("/tmp/worktree"))
+                },
+                state(),
+                HookMetadata::default()
+            )
+            .state
+            .lifecycle,
+            RunLifecycle::Ended
+        );
+    }
+}

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -42,7 +42,9 @@ pub enum ReconciliationAction {
     InjectPointer { worker_name: String, status: String },
     DrainOutbox { worker_name: String },
     MigratePane { worker_name: String },
+    MigrateGodPane,
     MarkWorkerOrphaned { worker_name: String },
+    EndWorker { worker_name: String },
     BindAgentIdentity { worker_name: String },
     EndRun,
 }
@@ -54,6 +56,8 @@ pub struct HookMetadata {
     pub worker_status: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub worker_agent_identity: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub god_workspace_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -70,28 +74,38 @@ pub fn reconcile(
     mut metadata: HookMetadata,
 ) -> Reconciliation {
     let mut actions = Vec::new();
-    let worker_name = match event {
+    let target = match event {
         IncomingEvent::AgentStatusChanged { pane_id, .. }
         | IncomingEvent::PaneExited { pane_id }
         | IncomingEvent::PaneClosed { pane_id }
-        | IncomingEvent::PaneAgentDetected { pane_id, .. } => worker_for_pane(&state, pane_id),
+        | IncomingEvent::PaneAgentDetected { pane_id, .. } => target_for_pane(&state, pane_id),
         IncomingEvent::PaneMoved {
             previous_pane_id, ..
-        } => worker_for_pane(&state, previous_pane_id),
+        } => target_for_pane(&state, previous_pane_id),
         IncomingEvent::WorkspaceClosed { workspace_id } => {
             worker_for_workspace(&state, workspace_id)
+                .map(Target::Worker)
+                .or_else(|| {
+                    (metadata.god_workspace_id.as_deref() == Some(workspace_id))
+                        .then_some(Target::God)
+                })
         }
         IncomingEvent::WorktreeRemoved {
             workspace_id,
             worktree_path,
-        } => worker_for_workspace(&state, workspace_id).or_else(|| {
-            worktree_path
-                .as_ref()
-                .and_then(|path| worker_for_worktree(&state, path))
-        }),
+        } => worker_for_workspace(&state, workspace_id)
+            .or_else(|| {
+                worktree_path
+                    .as_ref()
+                    .and_then(|path| worker_for_worktree(&state, path))
+            })
+            .map(Target::Worker)
+            .or_else(|| {
+                (metadata.god_workspace_id.as_deref() == Some(workspace_id)).then_some(Target::God)
+            }),
     };
 
-    let Some(worker_name) = worker_name else {
+    let Some(target) = target else {
         return Reconciliation {
             state,
             metadata,
@@ -102,6 +116,13 @@ pub fn reconcile(
 
     match event {
         IncomingEvent::AgentStatusChanged { status, .. } => {
+            let Target::Worker(worker_name) = target else {
+                return Reconciliation {
+                    state,
+                    metadata,
+                    actions,
+                };
+            };
             let previous = metadata
                 .worker_status
                 .insert(worker_name.clone(), status.clone());
@@ -128,30 +149,58 @@ pub fn reconcile(
             pane_id,
             workspace_id,
             ..
-        } => {
-            let worker = state
-                .workers
-                .get_mut(&worker_name)
-                .expect("matched worker exists");
-            worker.pane_id = Some(pane_id.clone());
-            if let Some(workspace_id) = workspace_id {
-                worker.workspace_id = Some(workspace_id.clone());
+        } => match target {
+            Target::Worker(worker_name) => {
+                let worker = state
+                    .workers
+                    .get_mut(&worker_name)
+                    .expect("matched worker exists");
+                worker.pane_id = Some(pane_id.clone());
+                if let Some(workspace_id) = workspace_id {
+                    worker.workspace_id = Some(workspace_id.clone());
+                }
+                actions.push(ReconciliationAction::MigratePane { worker_name });
             }
-            actions.push(ReconciliationAction::MigratePane { worker_name });
-        }
-        IncomingEvent::PaneExited { .. } | IncomingEvent::PaneClosed { .. } => {
-            state
-                .workers
-                .get_mut(&worker_name)
-                .expect("matched worker exists")
-                .lifecycle = WorkerLifecycle::Orphaned;
-            actions.push(ReconciliationAction::MarkWorkerOrphaned { worker_name });
-        }
+            Target::God => {
+                state.god_pane_id = pane_id.clone();
+                metadata.god_workspace_id = workspace_id.clone();
+                actions.push(ReconciliationAction::MigrateGodPane);
+            }
+        },
+        IncomingEvent::PaneExited { .. } | IncomingEvent::PaneClosed { .. } => match target {
+            Target::Worker(worker_name) => {
+                state
+                    .workers
+                    .get_mut(&worker_name)
+                    .expect("matched worker exists")
+                    .lifecycle = WorkerLifecycle::Orphaned;
+                actions.push(ReconciliationAction::MarkWorkerOrphaned { worker_name });
+                end_run_if_no_live_workers(&mut state, &mut actions);
+            }
+            Target::God => end_run(&mut state, &mut actions),
+        },
         IncomingEvent::WorkspaceClosed { .. } | IncomingEvent::WorktreeRemoved { .. } => {
-            state.lifecycle = RunLifecycle::Ended;
-            actions.push(ReconciliationAction::EndRun);
+            match target {
+                Target::Worker(worker_name) => {
+                    state
+                        .workers
+                        .get_mut(&worker_name)
+                        .expect("matched worker exists")
+                        .lifecycle = WorkerLifecycle::Ended;
+                    actions.push(ReconciliationAction::EndWorker { worker_name });
+                    end_run_if_no_live_workers(&mut state, &mut actions);
+                }
+                Target::God => end_run(&mut state, &mut actions),
+            }
         }
         IncomingEvent::PaneAgentDetected { agent, .. } => {
+            let Target::Worker(worker_name) = target else {
+                return Reconciliation {
+                    state,
+                    metadata,
+                    actions,
+                };
+            };
             if let Some(agent) = agent {
                 metadata
                     .worker_agent_identity
@@ -166,6 +215,39 @@ pub fn reconcile(
         metadata,
         actions,
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Target {
+    Worker(String),
+    God,
+}
+
+fn target_for_pane(state: &RunState, pane_id: &str) -> Option<Target> {
+    if state.god_pane_id == pane_id {
+        Some(Target::God)
+    } else {
+        worker_for_pane(state, pane_id).map(Target::Worker)
+    }
+}
+
+fn end_run_if_no_live_workers(state: &mut RunState, actions: &mut Vec<ReconciliationAction>) {
+    if state.workers.values().all(|worker| {
+        matches!(
+            worker.lifecycle,
+            WorkerLifecycle::Failed
+                | WorkerLifecycle::Ended
+                | WorkerLifecycle::Released
+                | WorkerLifecycle::Orphaned
+        )
+    }) {
+        end_run(state, actions);
+    }
+}
+
+fn end_run(state: &mut RunState, actions: &mut Vec<ReconciliationAction>) {
+    state.lifecycle = RunLifecycle::Ended;
+    actions.push(ReconciliationAction::EndRun);
 }
 
 fn worker_for_pane(state: &RunState, pane_id: &str) -> Option<String> {

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,6 +1,8 @@
 //! Durable run-board storage and matching from `docs/spec.md` sections 4 through 6.
 
+use crate::reconcile::HookMetadata;
 use crate::types::{RunLifecycle, RunState};
+use serde::Deserialize;
 use serde_json::Value;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
@@ -52,6 +54,12 @@ pub struct MatchedWorker {
     pub worker_name: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct HookEnvelope {
+    #[serde(default)]
+    hook: HookMetadata,
+}
+
 pub fn create_run(state_dir: &Path, state: RunState) -> Result<RunBoard, RunError> {
     validate_team_name(&state.spec.name)?;
 
@@ -69,7 +77,7 @@ pub fn create_run(state_dir: &Path, state: RunState) -> Result<RunBoard, RunErro
         dir: run_dir,
         state,
     };
-    if let Err(error) = save_run(&run) {
+    if let Err(error) = save_run_with_hook(&run, &HookMetadata::default()) {
         let _ = fs::remove_dir_all(&run.dir);
         return Err(error);
     }
@@ -87,10 +95,37 @@ pub fn load_run(run_dir: &Path) -> Result<RunBoard, RunError> {
 }
 
 pub fn save_run(run: &RunBoard) -> Result<(), RunError> {
-    let contents = toml::to_string_pretty(&run.state)?;
-    let mut file = File::create(run.dir.join(RUN_FILE))?;
+    let hook = load_hook_metadata(&run.dir)?;
+    save_run_with_hook(run, &hook)
+}
+
+pub fn load_hook_metadata(run_dir: &Path) -> Result<HookMetadata, RunError> {
+    let contents = fs::read_to_string(run_dir.join(RUN_FILE))?;
+    Ok(toml::from_str::<HookEnvelope>(&contents)?.hook)
+}
+
+pub fn save_run_with_hook(run: &RunBoard, hook: &HookMetadata) -> Result<(), RunError> {
+    let mut contents = toml::to_string_pretty(&run.state)?;
+    if hook != &HookMetadata::default() {
+        if !hook.worker_status.is_empty() {
+            contents.push_str("\n[hook.worker_status]\n");
+            contents.push_str(&toml::to_string(&hook.worker_status)?);
+        }
+        if !hook.worker_agent_identity.is_empty() {
+            contents.push_str("\n[hook.worker_agent_identity]\n");
+            contents.push_str(&toml::to_string(&hook.worker_agent_identity)?);
+        }
+    }
+    write_run_contents(&run.dir, &contents)
+}
+
+fn write_run_contents(run_dir: &Path, contents: &str) -> Result<(), RunError> {
+    let path = run_dir.join(RUN_FILE);
+    let temporary = run_dir.join(format!(".{RUN_FILE}.{}.tmp", std::process::id()));
+    let mut file = File::create(&temporary)?;
     file.write_all(contents.as_bytes())?;
     file.flush()?;
+    fs::rename(&temporary, &path)?;
     Ok(())
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -107,6 +107,13 @@ pub fn load_hook_metadata(run_dir: &Path) -> Result<HookMetadata, RunError> {
 pub fn save_run_with_hook(run: &RunBoard, hook: &HookMetadata) -> Result<(), RunError> {
     let mut contents = toml::to_string_pretty(&run.state)?;
     if hook != &HookMetadata::default() {
+        if let Some(god_workspace_id) = &hook.god_workspace_id {
+            contents.push_str("\n[hook]\n");
+            contents.push_str(&toml::to_string(&std::collections::BTreeMap::from([(
+                "god_workspace_id",
+                god_workspace_id,
+            )]))?);
+        }
         if !hook.worker_status.is_empty() {
             contents.push_str("\n[hook.worker_status]\n");
             contents.push_str(&toml::to_string(&hook.worker_status)?);

--- a/src/types.rs
+++ b/src/types.rs
@@ -120,6 +120,7 @@ pub enum WorkerLifecycle {
     Failed,
     Ended,
     Released,
+    Orphaned,
 }
 
 fn default_cwd() -> PathBuf {


### PR DESCRIPTION
Implement a pure hook reconciliation module that persists status and identity metadata atomically, injects completion pointers once per working-to-idle/done transition, and reconciles pane/workspace/worktree lifecycle events.

Registers lifecycle hooks, documents the at-most-once notification caveat, and adds fixture regressions for transitions, pane migration/orphaning, run ending, and agent detection.

Validation: cargo fmt --check; cargo clippy --all-targets -- -D warnings; cargo test (107 passed).

Closes #10. Closes #4.