### PR TITLE
fix: encode worker git contract in protocols

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -82,6 +82,12 @@ queues_midturn = true                # mid-turn pane run queues cleanly (live-ve
 `AGENTS.md`; it does not control the generated worker protocol. Every worker
 receives an explicit absolute-path pointer to its own protocol.
 
+The generated protocol's Git contract follows the worker's `worktree` flag.
+Worktree workers commit only on their configured branch, push it, and open a
+PR with `gh`; they never touch the main/default branch, merge, or tag. Shared-
+tree workers do not run Git: the coordinator owns Git operations, central
+gates, and merges.
+
 `queues_midturn` records whether a mid-turn `pane run` into this agent's TUI
 queues safely as a pending user message (verified for claude, spec §9).
 `false`/absent means the `msg` verb (§11) must not deliver while the target is
@@ -418,6 +424,9 @@ herdr-agent-team adopt <pane-id> --name <worker> [--role <text>]
 - **Topology:** star-only. Adopting into a mesh run is a hard error
   (immutable peer tables would go stale — ADR-0009 defers the amendment
   mechanism).
+- **Git:** adopted workers are shared-tree workers (`worktree = false`), so
+  their generated protocol keeps the no-Git rule; the coordinator owns Git
+  operations for the adopted pane's working tree.
 - **Agent kind:** from the pane's detected agent label, mapped into the
   launcher table. Unknown label → conservative synthetic policy
   (`submit_verify = true`, `queues_midturn = false`) + warning naming the

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -764,6 +764,9 @@ mod tests {
             .expect("read immutable adopted protocol");
         assert!(protocol.contains("- Worker: `newcomer`"));
         assert!(protocol.contains("- Workspace: `workspace-borrowed`"));
+        assert!(protocol.contains("This worker shares the coordinator's working tree."));
+        assert!(protocol.contains("Do not run git. The coordinator owns all git operations."));
+        assert!(!protocol.contains("open a PR with `gh`"));
         let calls = fake.calls();
         assert_eq!(calls[0], "pane_get:pane-adopted");
         assert!(calls.iter().any(|call| {

--- a/src/agents_md.rs
+++ b/src/agents_md.rs
@@ -67,6 +67,8 @@ protocol, not the repository's authored `AGENTS.md`.\n\n",
     writeln!(out, "- Working directory: `{}`\n", cwd.display())
         .expect("writing to String cannot fail");
 
+    render_git_contract(&mut out, worker);
+
     out.push_str("## Report protocol\n\n");
     out.push_str("Before you become idle, blocked, or done:\n\n");
     writeln!(
@@ -107,6 +109,32 @@ fn workspace_label(state: Option<&WorkerRunState>) -> String {
     state
         .and_then(|state| state.workspace_id.clone())
         .unwrap_or_else(|| "pending".to_owned())
+}
+
+fn render_git_contract(out: &mut String, worker: &WorkerSpec) {
+    out.push_str("## Git contract\n\n");
+
+    if worker.worktree {
+        let branch = worker
+            .branch
+            .as_deref()
+            .expect("validated worktree workers always have a branch");
+        writeln!(
+            out,
+            "This worker has a dedicated worktree on branch `{branch}`.\n"
+        )
+        .expect("writing to String cannot fail");
+        out.push_str(
+            "- Run git for this task: make small conventional commits on this branch, push it, and open a PR with `gh`.\n\
+- Never touch the main/default branch, merge, or tag.\n\
+- The coordinator reviews, runs gates centrally, and merges.\n\n",
+        );
+    } else {
+        out.push_str(
+            "This worker shares the coordinator's working tree.\n\n\
+- Do not run git. The coordinator owns all git operations.\n\n",
+        );
+    }
 }
 
 fn render_mesh_protocol(
@@ -271,6 +299,23 @@ mod tests {
         .iter()
         .all(|forbidden| !rendered.contains(forbidden)));
         assert_no_bare_msg_invocation(&rendered);
+    }
+
+    #[test]
+    fn shared_tree_worker_protocol_keeps_git_with_the_coordinator() {
+        let (team, run) = fixture(Topology::Star);
+        let rendered = render_agents_md_with_executable(
+            &team,
+            &team.workers[1],
+            &run,
+            Path::new(GOLDEN_RUN_DIR),
+            Path::new(GOLDEN_EXECUTABLE),
+        )
+        .unwrap();
+
+        assert!(rendered.contains("This worker shares the coordinator's working tree."));
+        assert!(rendered.contains("Do not run git. The coordinator owns all git operations."));
+        assert!(!rendered.contains("open a PR with `gh`"));
     }
 
     #[test]

--- a/tests/golden/agents_md_mesh.md
+++ b/tests/golden/agents_md_mesh.md
@@ -11,6 +11,14 @@
 - Workspace: `workspace-builder`
 - Working directory: `/repo/worktrees/builder`
 
+## Git contract
+
+This worker has a dedicated worktree on branch `feat/builder`.
+
+- Run git for this task: make small conventional commits on this branch, push it, and open a PR with `gh`.
+- Never touch the main/default branch, merge, or tag.
+- The coordinator reviews, runs gates centrally, and merges.
+
 ## Report protocol
 
 Before you become idle, blocked, or done:

--- a/tests/golden/agents_md_star.md
+++ b/tests/golden/agents_md_star.md
@@ -11,6 +11,14 @@
 - Workspace: `workspace-builder`
 - Working directory: `/repo/worktrees/builder`
 
+## Git contract
+
+This worker has a dedicated worktree on branch `feat/builder`.
+
+- Run git for this task: make small conventional commits on this branch, push it, and open a PR with `gh`.
+- Never touch the main/default branch, merge, or tag.
+- The coordinator reviews, runs gates centrally, and merges.
+
 ## Report protocol
 
 Before you become idle, blocked, or done:


### PR DESCRIPTION
## Summary
- render explicit branch-scoped Git guidance for worktree workers
- retain the coordinator-only Git rule for shared and adopted panes
- document the contract and cover worktree, shared-tree, and adoption protocols

## Verification
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test

Closes #15.