### PR TITLE
Persist Herdr agent sessions per run

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -182,9 +182,11 @@ feature.
    (atomically migrate pane/tab/workspace ids from `previous_pane_id`),
    `pane.exited` vs `pane.closed` (dead vs removed), `workspace.closed`,
    `worktree.removed`, and `pane.agent_detected` (bind identity earlier).
-2. **Full `agent_session` persistence**: store `{source, agent, kind,
-   value}` per worker (today only `.value` survives), plus the exact herdr
-   session/socket identity per run. Prerequisite for any real restart.
+2. **Full `agent_session` persistence** — **SHIPPED (#5, 2026-07-15)**:
+   store `{source, agent, kind, value}` per worker (while retaining the
+   legacy `agent_id` projection for old run boards), plus the exact
+   `HERDR_SOCKET_PATH` / `HERDR_SESSION` identity per run at spawn and adopt.
+   Prerequisite for any real restart; restart logic remains out of scope.
 3. **Schema-gated metadata + aggregate notifications**: publish `team` /
    `role` / `task` / `progress` via `pane report-metadata` tokens with
    `--seq`/`--ttl-ms` — only after a runtime schema probe confirms token
@@ -268,6 +270,11 @@ reference detail lives in `docs/research/` (ADR-0010 §3), not here.
   `TERM`/`COLORTERM`) `[source 2026-07-15]` — previously undocumented here.
   Event hooks additionally get the `HERDR_PLUGIN_*` set; full matrix in the
   research report Part A §2.
+- **Run identity persistence**: named sessions are selected with
+  `HERDR_SESSION`, and `HERDR_SOCKET_PATH` is the low-level override
+  `[source 2026-07-15]`. Each new or adopted run persists both values when
+  present, alongside the complete upstream `agent_session` reference per
+  worker; older run boards without these additive fields still deserialize.
 - **Plugin surface**: 21 hookable manifest events (not just
   `pane.agent_status_changed`); actions, panes, keybinds, link handlers
   available `[source 2026-07-15]`. High-frequency kinds

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -10,8 +10,8 @@ use crate::spawn::{
     write_worker_protocol, HerdrApi, SpawnError,
 };
 use crate::types::{
-    GodSpec, LauncherEntry, LauncherTable, RunLifecycle, RunState, TeamSpec, Topology,
-    WorkerLifecycle, WorkerRunState, WorkerSpec,
+    current_herdr_session_identity, GodSpec, LauncherEntry, LauncherTable, RunLifecycle, RunState,
+    TeamSpec, Topology, WorkerLifecycle, WorkerRunState, WorkerSpec,
 };
 use std::collections::BTreeMap;
 use std::env;
@@ -332,6 +332,7 @@ fn adopt_resolved<H: HerdrApi>(
             &pane,
         )?,
     };
+    run.state.herdr_session = current_herdr_session_identity();
 
     save_run(&run)?;
     let mut protocol_team = run.state.spec.clone();
@@ -442,6 +443,7 @@ fn bootstrap_run(
             workers: Vec::new(),
         },
         god_pane_id: god_pane_id.to_owned(),
+        herdr_session: current_herdr_session_identity(),
         workers: BTreeMap::new(),
         lifecycle: RunLifecycle::Active,
     };
@@ -457,6 +459,7 @@ fn insert_adopted_worker(state: &mut RunState, worker: &WorkerSpec, pane: &PaneI
             workspace_id: Some(pane.workspace_id.clone()),
             pane_id: Some(pane.pane_id.clone()),
             agent_id: pane.agent_id.clone(),
+            agent_session: pane.agent_session.clone(),
             worktree_path: None,
             adopted: true,
             lifecycle: WorkerLifecycle::Pending,
@@ -546,6 +549,12 @@ mod tests {
                     workspace_id: "workspace-borrowed".to_owned(),
                     agent: agent.map(str::to_owned),
                     agent_id: Some("session-adopted".to_owned()),
+                    agent_session: Some(crate::herdr::AgentSession {
+                        source: "herdr:claude".to_owned(),
+                        agent: "claude".to_owned(),
+                        kind: "id".to_owned(),
+                        value: "session-adopted".to_owned(),
+                    }),
                     agent_status: Some("idle".to_owned()),
                     cwd: Some(root.to_path_buf()),
                 },
@@ -628,12 +637,14 @@ mod tests {
                     workers: vec![existing],
                 },
                 god_pane_id: "god-pane".to_owned(),
+                herdr_session: Default::default(),
                 workers: BTreeMap::from([(
                     "existing".to_owned(),
                     WorkerRunState {
                         workspace_id: Some("workspace-existing".to_owned()),
                         pane_id: Some("pane-existing".to_owned()),
                         agent_id: Some("session-existing".to_owned()),
+                        agent_session: None,
                         worktree_path: None,
                         adopted: false,
                         lifecycle: WorkerLifecycle::Running,
@@ -827,6 +838,13 @@ mod tests {
         assert_eq!(persisted.state.god_pane_id, "god-current");
         assert_eq!(persisted.state.spec.workers.len(), 1);
         assert!(persisted.state.workers["researcher"].adopted);
+        assert_eq!(
+            persisted.state.workers["researcher"]
+                .agent_session
+                .as_ref()
+                .map(|session| session.source.as_str()),
+            Some("herdr:claude")
+        );
         let run_toml = fs::read_to_string(outcome.run.dir.join("run.toml"))
             .expect("read reconstructed run spec");
         assert!(run_toml.contains("name = \"adhoc\""));

--- a/src/agents_md.rs
+++ b/src/agents_md.rs
@@ -195,6 +195,7 @@ mod tests {
             workspace_id: Some(workspace_id.to_owned()),
             pane_id: Some(format!("{workspace_id}-pane")),
             agent_id: None,
+            agent_session: None,
             worktree_path: worktree_path.map(PathBuf::from),
             adopted: false,
             lifecycle: WorkerLifecycle::Running,
@@ -202,6 +203,7 @@ mod tests {
         let run = RunState {
             spec: team.clone(),
             god_pane_id: "god-pane-7".to_owned(),
+            herdr_session: Default::default(),
             workers: BTreeMap::from([
                 (
                     "builder".to_owned(),

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -49,6 +49,7 @@ pub struct PaneInfo {
     pub workspace_id: String,
     pub agent: Option<String>,
     pub agent_id: Option<String>,
+    pub agent_session: Option<AgentSession>,
     pub agent_status: Option<String>,
     pub cwd: Option<PathBuf>,
 }
@@ -59,13 +60,18 @@ pub struct AgentInfo {
     pub workspace_id: String,
     pub agent: Option<String>,
     pub agent_id: Option<String>,
+    pub agent_session: Option<AgentSession>,
     #[serde(rename = "agent_status")]
     pub status: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-struct AgentSessionRef {
-    value: String,
+/// An opaque agent-session reference reported by Herdr.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentSession {
+    pub source: String,
+    pub agent: String,
+    pub kind: String,
+    pub value: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -73,7 +79,7 @@ struct PaneInfoWire {
     pane_id: String,
     workspace_id: String,
     agent: Option<String>,
-    agent_session: Option<AgentSessionRef>,
+    agent_session: Option<AgentSession>,
     agent_status: Option<String>,
     cwd: Option<PathBuf>,
 }
@@ -84,11 +90,16 @@ impl<'de> Deserialize<'de> for PaneInfo {
         D: serde::Deserializer<'de>,
     {
         let wire = PaneInfoWire::deserialize(deserializer)?;
+        let agent_id = wire
+            .agent_session
+            .as_ref()
+            .map(|session| session.value.clone());
         Ok(Self {
             pane_id: wire.pane_id,
             workspace_id: wire.workspace_id,
             agent: wire.agent,
-            agent_id: wire.agent_session.map(|session| session.value),
+            agent_id,
+            agent_session: wire.agent_session,
             agent_status: wire.agent_status,
             cwd: wire.cwd,
         })
@@ -100,7 +111,7 @@ struct AgentInfoWire {
     pane_id: String,
     workspace_id: String,
     agent: Option<String>,
-    agent_session: Option<AgentSessionRef>,
+    agent_session: Option<AgentSession>,
     #[serde(rename = "agent_status")]
     status: Option<String>,
 }
@@ -111,11 +122,16 @@ impl<'de> Deserialize<'de> for AgentInfo {
         D: serde::Deserializer<'de>,
     {
         let wire = AgentInfoWire::deserialize(deserializer)?;
+        let agent_id = wire
+            .agent_session
+            .as_ref()
+            .map(|session| session.value.clone());
         Ok(Self {
             pane_id: wire.pane_id,
             workspace_id: wire.workspace_id,
             agent: wire.agent,
-            agent_id: wire.agent_session.map(|session| session.value),
+            agent_id,
+            agent_session: wire.agent_session,
             status: wire.status,
         })
     }
@@ -660,6 +676,15 @@ mod tests {
             pane.agent_id.as_deref(),
             Some("019f6268-cf99-7110-8c8f-e94817e05fad")
         );
+        assert_eq!(
+            pane.agent_session,
+            Some(AgentSession {
+                source: "herdr:codex".to_owned(),
+                agent: "codex".to_owned(),
+                kind: "id".to_owned(),
+                value: "019f6268-cf99-7110-8c8f-e94817e05fad".to_owned(),
+            })
+        );
 
         let agents = parse_agent_list(LIVE_AGENT_LIST).unwrap();
         assert_eq!(agents.len(), 1);
@@ -668,6 +693,13 @@ mod tests {
         assert_eq!(
             agents[0].agent_id.as_deref(),
             Some("019f6268-cf99-7110-8c8f-e94817e05fad")
+        );
+        assert_eq!(
+            agents[0]
+                .agent_session
+                .as_ref()
+                .map(|session| session.kind.as_str()),
+            Some("id")
         );
     }
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -405,12 +405,14 @@ mod tests {
                     }],
                 },
                 god_pane_id: "god-pane".to_owned(),
+                herdr_session: Default::default(),
                 workers: BTreeMap::from([(
                     worker_name,
                     WorkerRunState {
                         workspace_id: Some("worker-workspace".to_owned()),
                         pane_id: Some(worker_pane.to_owned()),
                         agent_id: Some("agent-1".to_owned()),
+                        agent_session: None,
                         worktree_path: None,
                         adopted: false,
                         lifecycle: WorkerLifecycle::Running,
@@ -856,6 +858,7 @@ mod tests {
                 workspace_id: Some("reviewer-workspace".to_owned()),
                 pane_id: Some("reviewer-pane".to_owned()),
                 agent_id: Some("agent-2".to_owned()),
+                agent_session: None,
                 worktree_path: None,
                 adopted: false,
                 lifecycle: WorkerLifecycle::Running,

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -573,6 +573,7 @@ mod tests {
                 workspace_id: "workspace".to_owned(),
                 agent: Some(self.agent.clone()),
                 agent_id: Some("session".to_owned()),
+                agent_session: None,
                 agent_status: self.status.clone(),
                 cwd: None,
             })
@@ -632,12 +633,14 @@ mod tests {
                     workers: vec![worker],
                 },
                 god_pane_id: "god-pane".to_owned(),
+                herdr_session: Default::default(),
                 workers: BTreeMap::from([(
                     worker_name.to_owned(),
                     WorkerRunState {
                         workspace_id: Some("workspace".to_owned()),
                         pane_id: Some("worker-pane".to_owned()),
                         agent_id: Some("session".to_owned()),
+                        agent_session: None,
                         worktree_path: None,
                         adopted: false,
                         lifecycle: WorkerLifecycle::Running,

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -294,6 +294,7 @@ mod tests {
                 }],
             },
             god_pane_id: "god".to_owned(),
+            herdr_session: Default::default(),
             lifecycle: RunLifecycle::Active,
             workers: BTreeMap::from([(
                 "builder".to_owned(),
@@ -301,6 +302,7 @@ mod tests {
                     workspace_id: Some("workspace-1".to_owned()),
                     pane_id: Some("pane-1".to_owned()),
                     agent_id: None,
+                    agent_session: None,
                     worktree_path: Some(PathBuf::from("/tmp/worktree")),
                     adopted: false,
                     lifecycle: WorkerLifecycle::Running,

--- a/src/run.rs
+++ b/src/run.rs
@@ -233,7 +233,11 @@ fn allocate_run_dir(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{GodSpec, TeamSpec, Topology, WorkerLifecycle, WorkerRunState, WorkerSpec};
+    use crate::herdr::AgentSession;
+    use crate::types::{
+        GodSpec, HerdrSessionIdentity, TeamSpec, Topology, WorkerLifecycle, WorkerRunState,
+        WorkerSpec,
+    };
     use serde_json::json;
     use std::collections::BTreeMap;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -277,6 +281,7 @@ mod tests {
                 workspace_id: Some("workspace-1".to_owned()),
                 pane_id: Some(pane_id.to_owned()),
                 agent_id: Some("agent-1".to_owned()),
+                agent_session: None,
                 worktree_path: Some(PathBuf::from("/tmp/worktree")),
                 adopted: false,
                 lifecycle: WorkerLifecycle::Running,
@@ -301,6 +306,7 @@ mod tests {
                 }],
             },
             god_pane_id: "god-pane".to_owned(),
+            herdr_session: Default::default(),
             workers,
             lifecycle: RunLifecycle::Active,
         }
@@ -324,6 +330,69 @@ mod tests {
         assert!(run.dir.join(RUN_FILE).is_file());
         assert!(run.dir.join(INBOX_DIR).is_dir());
         assert_eq!(load_run(&run.dir).expect("load run"), run);
+    }
+
+    #[test]
+    fn run_toml_round_trips_full_agent_session_and_herdr_identity() {
+        let temp = TempDir::new();
+        let mut state = run_state("alpha", "pane-alpha");
+        state.herdr_session = HerdrSessionIdentity::from_environment(
+            Some(PathBuf::from("/run/user/1000/herdr/named.sock")),
+            Some("named".to_owned()),
+        );
+        state.workers.get_mut("builder").unwrap().agent_session = Some(AgentSession {
+            source: "herdr:codex".to_owned(),
+            agent: "codex".to_owned(),
+            kind: "id".to_owned(),
+            value: "opaque-session".to_owned(),
+        });
+
+        let run = create_run(temp.path(), state.clone()).expect("create run");
+        let persisted = load_run(&run.dir).expect("load run");
+        assert_eq!(persisted.state, state);
+
+        let contents = fs::read_to_string(run.dir.join(RUN_FILE)).expect("read run TOML");
+        assert!(contents.contains("[herdr_session]"));
+        assert!(contents.contains("[workers.builder.agent_session]"));
+    }
+
+    #[test]
+    fn old_run_toml_without_session_fields_still_loads() {
+        let state: RunState = toml::from_str(
+            r#"
+god_pane_id = "god-pane"
+lifecycle = "active"
+
+[spec]
+name = "legacy"
+topology = "star"
+cwd = "/tmp/project"
+
+[spec.god]
+target = "self"
+
+[[spec.workers]]
+name = "builder"
+agent = "codex"
+role = "builder"
+worktree = false
+brief = "brief.md"
+
+[workers.builder]
+workspace_id = "workspace-1"
+pane_id = "pane-1"
+agent_id = "opaque-id"
+lifecycle = "running"
+"#,
+        )
+        .expect("deserialize old run TOML");
+
+        assert!(state.herdr_session.is_empty());
+        assert_eq!(
+            state.workers["builder"].agent_id.as_deref(),
+            Some("opaque-id")
+        );
+        assert_eq!(state.workers["builder"].agent_session, None);
     }
 
     #[test]

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -9,8 +9,8 @@ use crate::spec::{
     SpecError,
 };
 use crate::types::{
-    AgentsMdMode, LauncherEntry, LauncherTable, RunLifecycle, RunState, TeamSpec, WorkerLifecycle,
-    WorkerRunState, WorkerSpec,
+    current_herdr_session_identity, AgentsMdMode, LauncherEntry, LauncherTable, RunLifecycle,
+    RunState, TeamSpec, WorkerLifecycle, WorkerRunState, WorkerSpec,
 };
 use std::collections::BTreeMap;
 use std::env;
@@ -425,6 +425,7 @@ where
                     workspace_id: None,
                     pane_id: None,
                     agent_id: None,
+                    agent_session: None,
                     worktree_path: None,
                     adopted: false,
                     lifecycle: WorkerLifecycle::Pending,
@@ -435,6 +436,7 @@ where
     let state = RunState {
         spec: spec.clone(),
         god_pane_id,
+        herdr_session: current_herdr_session_identity(),
         workers,
         lifecycle: RunLifecycle::Active,
     };
@@ -645,11 +647,13 @@ fn launch_worker<H: HerdrApi>(
     )?;
 
     let pane = wait_for_agent_info(herdr, worker, &pane_id, agent_info_timeout)?;
-    run.state
+    let state = run
+        .state
         .workers
         .get_mut(&worker.name)
-        .expect("run state is initialized from the same team spec")
-        .agent_id = pane.agent_id.clone();
+        .expect("run state is initialized from the same team spec");
+    state.agent_id = pane.agent_id.clone();
+    state.agent_session = pane.agent_session.clone();
     save_run(run)?;
 
     let prompt = launch_prompt(worker, launcher, &worker_protocol_path(run, worker));
@@ -1107,6 +1111,14 @@ mod tests {
                 }),
                 agent_id: (agent_detected && !self.omit_agent_id.get() && !delayed)
                     .then(|| format!("agent-session-{pane_id}")),
+                agent_session: (agent_detected && !self.omit_agent_id.get() && !delayed).then(
+                    || crate::herdr::AgentSession {
+                        source: "herdr:test".to_owned(),
+                        agent: "claude".to_owned(),
+                        kind: "id".to_owned(),
+                        value: format!("agent-session-{pane_id}"),
+                    },
+                ),
                 agent_status: Some("idle".to_owned()),
                 cwd: None,
             })
@@ -1543,6 +1555,14 @@ mod tests {
             "persist the opaque ID returned by the typed client"
         );
         assert_eq!(worker.lifecycle, WorkerLifecycle::Running);
+        assert_eq!(
+            worker
+                .agent_session
+                .as_ref()
+                .map(|session| session.source.as_str()),
+            Some("herdr:test"),
+            "persist the complete agent-session reference"
+        );
         let calls = fake.calls();
         assert_eq!(calls[0], "health_check");
         assert!(calls.iter().any(|call| call == "pane_run:pane-1:'claude'"));

--- a/src/status_kill.rs
+++ b/src/status_kill.rs
@@ -523,6 +523,7 @@ mod tests {
             workspace_id: Some(workspace.to_owned()),
             pane_id: Some(pane.to_owned()),
             agent_id: Some(format!("agent-{pane}")),
+            agent_session: None,
             worktree_path: Some(worktree_root.join(worktree)),
             adopted: false,
             lifecycle: WorkerLifecycle::Running,
@@ -538,6 +539,7 @@ mod tests {
                 workers,
             },
             god_pane_id: "god-pane".to_owned(),
+            herdr_session: Default::default(),
             workers: BTreeMap::from([
                 (
                     "builder".to_owned(),
@@ -570,6 +572,7 @@ mod tests {
             workspace_id: "workspace-builder".to_owned(),
             agent: Some("codex".to_owned()),
             agent_id: None,
+            agent_session: None,
             status: Some("working".to_owned()),
         }]);
 
@@ -599,6 +602,7 @@ mod tests {
             workspace_id: "workspace-builder".to_owned(),
             agent: Some("codex".to_owned()),
             agent_id: None,
+            agent_session: None,
             status: Some("idle".to_owned()),
         }];
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -83,6 +83,8 @@ pub type LauncherTable = BTreeMap<String, LauncherEntry>;
 pub struct RunState {
     pub spec: TeamSpec,
     pub god_pane_id: String,
+    #[serde(default, skip_serializing_if = "HerdrSessionIdentity::is_empty")]
+    pub herdr_session: HerdrSessionIdentity,
     pub workers: BTreeMap<String, WorkerRunState>,
     pub lifecycle: RunLifecycle,
 }
@@ -97,10 +99,38 @@ pub struct WorkerRunState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_session: Option<crate::herdr::AgentSession>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_path: Option<PathBuf>,
     #[serde(default)]
     pub adopted: bool,
     pub lifecycle: WorkerLifecycle,
+}
+
+/// The Herdr runtime selected when this run was created or adopted.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HerdrSessionIdentity {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub socket_path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl HerdrSessionIdentity {
+    pub fn from_environment(socket_path: Option<PathBuf>, name: Option<String>) -> Self {
+        Self { socket_path, name }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.socket_path.is_none() && self.name.is_none()
+    }
+}
+
+pub fn current_herdr_session_identity() -> HerdrSessionIdentity {
+    HerdrSessionIdentity::from_environment(
+        std::env::var_os("HERDR_SOCKET_PATH").map(PathBuf::from),
+        std::env::var("HERDR_SESSION").ok(),
+    )
 }
 
 /// Whether a durable team run is still active (spec sections 4 and 6).


### PR DESCRIPTION
## Summary
- preserve the complete upstream `agent_session` reference per worker while retaining legacy `agent_id`
- persist `HERDR_SOCKET_PATH` and `HERDR_SESSION` with spawned and adopted runs
- cover TOML round-trips, old-run compatibility, spawn/adopt persistence, and update the roadmap

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

Closes #5.