### PR TITLE
feat: publish team metadata and alerts

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -193,12 +193,18 @@ feature.
    legacy `agent_id` projection for old run boards), plus the exact
    `HERDR_SOCKET_PATH` / `HERDR_SESSION` identity per run at spawn and adopt.
    Prerequisite for any real restart; restart logic remains out of scope.
-3. **Schema-gated metadata + aggregate notifications**: publish `team` /
-   `role` / `task` / `progress` via `pane report-metadata` tokens with
-   `--seq`/`--ttl-ms` — only after a runtime schema probe confirms token
-   support (preview surface, ADR-0010); `display_agent`/title fallback
-   otherwise. `notification show` for team-complete / blocked-beyond-
-   threshold / unrecoverable-exit only — never per status flip.
+3. **Schema-gated metadata + aggregate notifications — SHIPPED (#6,
+   2026-07-15)**: the runtime probe maps the team facts to the installed
+   `pane report-metadata` surface: compact `team/role` in `custom_status`,
+   task (when available) in `title`, and a status label. It uses a stable
+   plugin `--source` and monotonic per-worker `--seq`; explicit attention
+   pings use `--ttl-ms`. `herdr api schema --json` is cached per run before the
+   first write: absent custom tokens fall back to `display_agent`/title.
+   `notification show` is once per aggregate team-complete, blocked-duration,
+   unrecoverable-exit, or explicit needs-attention condition — never per
+   ordinary status flip. `HERDR_AGENT_TEAM_BLOCKED_THRESHOLD_MS` configures
+   the blocked-duration policy (default: five minutes; checked on subsequent
+   lifecycle/status events because this plugin has no daemon).
 4. **Native board pane**: `[[panes]]` entrypoint (durable tab placement +
    popup variant), `open-board` action, `plugin_action` keybinds, link
    handler making report/task pointers clickable. Board shows team
@@ -286,6 +292,17 @@ reference detail lives in `docs/research/` (ADR-0010 §3), not here.
   available `[source 2026-07-15]`. High-frequency kinds
   (`pane.output_changed`, `layout.updated`, …) are deliberately not
   plugin-hookable — direct subscription territory (ADR-0011).
+- **Metadata surface and coexistence**: `pane report-metadata` on installed
+  herdr 0.7.3 accepts `--title`, `--display-agent`, `--custom-status`,
+  `--state-label`, `--seq`, and `--ttl-ms` `[live 2026-07-15]`. A
+  plugin-scoped `--source caioniehues:herdr-agent-team` write on an active
+  Codex pane preserved its native `agent`/`agent_status` while adding only
+  presentation metadata `[live 2026-07-15]`; the plugin never calls
+  `pane report-agent`. The tested `--applies-to-source herdr:codex` filter
+  produced no visible update despite that pane's `agent_session.source`, so
+  the plugin deliberately omits that restrictive filter and relies on its
+  own stable source id. Schema absence still selects the fallback path
+  `[preview gate]`.
 
 ### Build-time verification TODOs (resolved)
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -373,7 +373,7 @@ herdr primitives; they get one plugin verb.
 ### `msg` subcommand
 
 ```
-herdr-agent-team msg <target> <text> [--run <run-dir>]
+herdr-agent-team msg <target> <text> [--attention] [--run <run-dir>]
 ```
 
 - `<target>`: `god` or a worker name from the active run. Resolution: name →
@@ -391,6 +391,11 @@ herdr-agent-team msg <target> <text> [--run <run-dir>]
 - Text is treated as opaque payload; the mesh `<agent-msg>` envelope
   (ADR-0003) travels inside it. Long/durable content goes in a file and the
   message carries the pointer — same rule as everywhere else.
+- `--attention` is valid only for a worker-to-`god` message: the worker's
+  `HERDR_PANE_ID` identifies the run member, the hook metadata records one
+  pending transient metadata ping, and `notification show` is emitted only
+  once for that worker. This is the explicit attention channel; agent status
+  values remain Herdr's fixed enum.
 
 ### Outbox + hook drain
 

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -1,5 +1,6 @@
 //! Typed wrapper for Herdr CLI operations required by `docs/spec.md` sections 4, 6, and 9.
 
+use crate::metadata::{MetadataUpdate, SOURCE};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -273,6 +274,60 @@ impl HerdrClient {
         let args = args(["pane", "get"]).with(pane_id).finish();
         let stdout = self.invoke(&args)?;
         parse_pane_info(&stdout).map_err(|message| self.invalid_response(&args, message))
+    }
+
+    pub fn api_schema(&self) -> Result<String, HerdrError> {
+        self.invoke(&args(["api", "schema", "--json"]).finish())
+    }
+
+    pub fn pane_report_metadata(
+        &self,
+        pane_id: &str,
+        update: &MetadataUpdate,
+    ) -> Result<(), HerdrError> {
+        let mut command = args(["pane", "report-metadata"])
+            .with(pane_id)
+            .with("--source")
+            .with(SOURCE);
+        if let Some(title) = &update.title {
+            command = command.with("--title").with(title);
+        }
+        if let Some(display_agent) = &update.display_agent {
+            command = command.with("--display-agent").with(display_agent);
+        }
+        if let Some(custom_status) = &update.custom_status {
+            command = command.with("--custom-status").with(custom_status);
+        }
+        if let Some((status, label)) = &update.state_label {
+            command = command
+                .with("--state-label")
+                .with(format!("{status}={label}"));
+        }
+        if let Some(seq) = update.seq {
+            command = command.with("--seq").with(seq.to_string());
+        }
+        if let Some(ttl_ms) = update.ttl_ms {
+            command = command.with("--ttl-ms").with(ttl_ms.to_string());
+        }
+        self.invoke(&command.finish())?;
+        Ok(())
+    }
+
+    pub fn notification_show(
+        &self,
+        title: &str,
+        body: &str,
+        sound: &str,
+    ) -> Result<(), HerdrError> {
+        let args = args(["notification", "show"])
+            .with(title)
+            .with("--body")
+            .with(body)
+            .with("--sound")
+            .with(sound)
+            .finish();
+        self.invoke(&args)?;
+        Ok(())
     }
 
     fn invoke(&self, args: &[OsString]) -> Result<String, HerdrError> {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,12 +1,14 @@
 //! Push-based worker status report and outbox hook from `docs/spec.md` sections 5 and 11.
 
 use crate::herdr::HerdrClient;
+use crate::metadata::{map_facts, MetadataCapabilities, MetadataFacts};
 use crate::msg;
-use crate::reconcile::{reconcile, IncomingEvent, ReconciliationAction};
+use crate::reconcile::{reconcile_at, IncomingEvent, ReconciliationAction};
 use crate::run;
 use serde_json::{json, Value};
 use std::fmt::Display;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -63,9 +65,33 @@ pub fn on_agent_status(
 
     for mut run in run::list_active_runs(state_dir)? {
         let metadata = run::load_hook_metadata(&run.dir)?;
-        let reconciliation = reconcile(&event, run.state.clone(), metadata);
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(run::RunError::from)?
+            .as_millis()
+            .min(u128::from(u64::MAX)) as u64;
+        let blocked_threshold_ms = std::env::var("HERDR_AGENT_TEAM_BLOCKED_THRESHOLD_MS")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(300_000);
+        let mut reconciliation = reconcile_at(
+            &event,
+            run.state.clone(),
+            metadata,
+            now_ms,
+            blocked_threshold_ms,
+        );
         if reconciliation.actions.is_empty() {
             continue;
+        }
+        if reconciliation.metadata.metadata_capabilities.is_none()
+            && reconciliation
+                .actions
+                .iter()
+                .any(|action| matches!(action, ReconciliationAction::PublishMetadata { .. }))
+        {
+            reconciliation.metadata.metadata_capabilities =
+                Some(MetadataCapabilities::from_schema(&herdr.api_schema()?));
         }
         run.state = reconciliation.state;
         run::save_run_with_hook(&run, &reconciliation.metadata)?;
@@ -83,6 +109,45 @@ pub fn on_agent_status(
                     status,
                 } => {
                     inject_pointer(&run, &worker_name, &status, herdr)?;
+                }
+                ReconciliationAction::PublishMetadata {
+                    worker_name,
+                    status,
+                    sequence,
+                } => {
+                    let Some(capabilities) = reconciliation.metadata.metadata_capabilities.as_ref()
+                    else {
+                        continue;
+                    };
+                    let worker = run
+                        .state
+                        .spec
+                        .workers
+                        .iter()
+                        .find(|worker| worker.name == worker_name)
+                        .expect("reconciled worker is in spec");
+                    if let Some(update) = map_facts(
+                        MetadataFacts {
+                            team: &run.state.spec.name,
+                            role: &worker.role,
+                            task: None,
+                            status: &status,
+                        },
+                        capabilities,
+                        sequence,
+                    ) {
+                        if let Some(pane_id) = run
+                            .state
+                            .workers
+                            .get(&worker_name)
+                            .and_then(|worker| worker.pane_id.as_deref())
+                        {
+                            herdr.pane_report_metadata(pane_id, &update)?;
+                        }
+                    }
+                }
+                ReconciliationAction::Notify { title, body, sound } => {
+                    herdr.notification_show(&title, &body, &sound)?
                 }
                 ReconciliationAction::RecordEvent
                 | ReconciliationAction::TrackAgentStatus { .. }
@@ -630,7 +695,12 @@ mod tests {
             .map(|line| serde_json::from_str::<Value>(line).unwrap())
             .collect::<Vec<_>>();
         assert_eq!(events, [captured_event, event_with_optional_fields]);
-        assert!(!fake.log.exists(), "non-terminal statuses must not inject");
+        assert!(
+            fake.argv()
+                .windows(2)
+                .all(|window| window != ["pane", "run"]),
+            "non-terminal statuses must not inject pointers"
+        );
     }
 
     #[test]
@@ -672,9 +742,8 @@ mod tests {
         let report_path = run.dir.join("inbox/builder.md");
         assert!(report_path.is_absolute());
         let argv = fake.argv();
-        assert_eq!(
-            argv,
-            [
+        assert!(argv.windows(4).any(|window| window
+            == [
                 "pane",
                 "run",
                 "god-pane",
@@ -682,8 +751,10 @@ mod tests {
                     "[team alpha] builder is blocked — report: {}",
                     report_path.display()
                 ),
-            ]
-        );
+            ]));
+        assert!(argv
+            .windows(3)
+            .any(|window| window == ["notification", "show", "Team complete"]));
     }
 
     #[test]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -114,6 +114,7 @@ pub fn on_agent_status(
                     worker_name,
                     status,
                     sequence,
+                    attention,
                 } => {
                     let Some(capabilities) = reconciliation.metadata.metadata_capabilities.as_ref()
                     else {
@@ -132,6 +133,7 @@ pub fn on_agent_status(
                             role: &worker.role,
                             task: None,
                             status: &status,
+                            attention,
                         },
                         capabilities,
                         sequence,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ pub mod agents_md;
 pub mod herdr;
 pub mod hook;
 pub mod launcher;
+pub mod metadata;
 pub mod msg;
 pub mod reconcile;
 pub mod run;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,117 @@
+//! Schema-gated, display-only metadata for team workers.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const SOURCE: &str = "caioniehues:herdr-agent-team";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetadataCapabilities {
+    pub report_metadata: bool,
+    pub title: bool,
+    pub display_agent: bool,
+    pub custom_status: bool,
+    pub state_labels: bool,
+    pub seq: bool,
+    pub ttl_ms: bool,
+}
+
+impl MetadataCapabilities {
+    pub fn from_schema(schema: &str) -> Self {
+        let Ok(schema) = serde_json::from_str::<Value>(schema) else {
+            return Self::default();
+        };
+        let Some(params) = schema
+            .pointer("/schemas/request/$defs/PaneReportMetadataParams")
+            .and_then(Value::as_object)
+        else {
+            return Self::default();
+        };
+        let properties = params.get("properties").and_then(Value::as_object);
+        let has = |name| properties.is_some_and(|properties| properties.contains_key(name));
+        Self {
+            report_metadata: has("pane_id") && has("source"),
+            title: has("title"),
+            display_agent: has("display_agent"),
+            custom_status: has("custom_status"),
+            state_labels: has("state_labels"),
+            seq: has("seq"),
+            ttl_ms: has("ttl_ms"),
+        }
+    }
+
+    pub fn can_publish(&self) -> bool {
+        self.report_metadata && (self.title || self.display_agent)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetadataFacts<'a> {
+    pub team: &'a str,
+    pub role: &'a str,
+    pub task: Option<&'a str>,
+    pub status: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetadataUpdate {
+    pub title: Option<String>,
+    pub display_agent: Option<String>,
+    pub custom_status: Option<String>,
+    pub state_label: Option<(String, String)>,
+    pub seq: Option<u64>,
+    pub ttl_ms: Option<u64>,
+}
+
+/// Maps team-domain facts to the tokens exposed by the installed Herdr schema.
+pub fn map_facts(
+    facts: MetadataFacts<'_>,
+    capabilities: &MetadataCapabilities,
+    sequence: u64,
+) -> Option<MetadataUpdate> {
+    if !capabilities.can_publish() {
+        return None;
+    }
+    let compact = format!("{}/{}", facts.team, facts.role);
+    Some(MetadataUpdate {
+        title: capabilities
+            .title
+            .then(|| facts.task.map(str::to_owned))
+            .flatten(),
+        display_agent: capabilities.display_agent.then(|| compact.clone()),
+        custom_status: capabilities.custom_status.then_some(compact.clone()),
+        state_label: capabilities
+            .state_labels
+            .then(|| (facts.status.to_owned(), compact)),
+        seq: capabilities.seq.then_some(sequence),
+        // An explicit attention request is a transient presentation ping.
+        ttl_ms: (facts.status == "needs_attention" && capabilities.ttl_ms).then_some(30_000),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_gate_falls_back_when_custom_tokens_are_absent() {
+        let schema = r#"{"schemas":{"request":{"$defs":{"PaneReportMetadataParams":{"properties":{"pane_id":{},"source":{},"title":{},"display_agent":{}}}}}}}"#;
+        let capabilities = MetadataCapabilities::from_schema(schema);
+        let update = map_facts(
+            MetadataFacts {
+                team: "wave3",
+                role: "builder",
+                task: Some("implement gate"),
+                status: "working",
+            },
+            &capabilities,
+            3,
+        )
+        .expect("fallback remains publishable");
+        assert_eq!(update.title.as_deref(), Some("implement gate"));
+        assert_eq!(update.display_agent.as_deref(), Some("wave3/builder"));
+        assert_eq!(update.custom_status, None);
+        assert_eq!(update.state_label, None);
+        assert_eq!(update.seq, None);
+    }
+}

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -51,6 +51,7 @@ pub struct MetadataFacts<'a> {
     pub role: &'a str,
     pub task: Option<&'a str>,
     pub status: &'a str,
+    pub attention: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -85,7 +86,7 @@ pub fn map_facts(
             .then(|| (facts.status.to_owned(), compact)),
         seq: capabilities.seq.then_some(sequence),
         // An explicit attention request is a transient presentation ping.
-        ttl_ms: (facts.status == "needs_attention" && capabilities.ttl_ms).then_some(30_000),
+        ttl_ms: (facts.attention && capabilities.ttl_ms).then_some(30_000),
     })
 }
 
@@ -103,6 +104,7 @@ mod tests {
                 role: "builder",
                 task: Some("implement gate"),
                 status: "working",
+                attention: false,
             },
             &capabilities,
             3,
@@ -113,5 +115,28 @@ mod tests {
         assert_eq!(update.custom_status, None);
         assert_eq!(update.state_label, None);
         assert_eq!(update.seq, None);
+    }
+
+    #[test]
+    fn attention_fact_uses_a_transient_ttl_when_supported() {
+        let capabilities = MetadataCapabilities {
+            report_metadata: true,
+            display_agent: true,
+            ttl_ms: true,
+            ..Default::default()
+        };
+        let update = map_facts(
+            MetadataFacts {
+                team: "wave3",
+                role: "builder",
+                task: None,
+                status: "working",
+                attention: true,
+            },
+            &capabilities,
+            1,
+        )
+        .expect("supported metadata");
+        assert_eq!(update.ttl_ms, Some(30_000));
     }
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -5,7 +5,9 @@ use crate::launcher::{
     conservative_adopted_launcher, default_launcher_table, launcher_entry, load_launcher_table,
     LauncherError,
 };
-use crate::run::{list_active_runs, load_run, RunBoard, RunError};
+use crate::run::{
+    list_active_runs, load_hook_metadata, load_run, save_run_with_hook, RunBoard, RunError,
+};
 use crate::types::{LauncherEntry, LauncherTable, RunLifecycle};
 use std::collections::BTreeSet;
 use std::env;
@@ -16,7 +18,8 @@ use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 use thiserror::Error;
 
-const MSG_USAGE: &str = "usage: herdr-agent-team msg <target> <text> [--run <run-dir>]";
+const MSG_USAGE: &str =
+    "usage: herdr-agent-team msg <target> <text> [--attention] [--run <run-dir>]";
 const SUBMIT_GRACE_TIMEOUT: Duration = Duration::from_secs(2);
 const SUBMIT_VERIFY_TIMEOUT: Duration = Duration::from_secs(30);
 const OUTBOX_DIR: &str = "outbox";
@@ -73,6 +76,12 @@ pub enum MsgError {
 
     #[error("message submission to `{target}` timed out waiting for agent status `working`")]
     SubmissionTimeout { target: String },
+
+    #[error("--attention is only valid for a worker message to god")]
+    AttentionTarget,
+
+    #[error("--attention requires HERDR_PANE_ID for a recorded worker pane")]
+    AttentionSource,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -80,6 +89,7 @@ struct MsgArguments {
     target: String,
     text: String,
     run_dir: Option<PathBuf>,
+    attention: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -111,11 +121,16 @@ trait HerdrApi {
         status: &str,
         timeout: Duration,
     ) -> Result<WaitOutcome, HerdrError>;
+    fn notification_show(&self, title: &str, body: &str, sound: &str) -> Result<(), HerdrError>;
 }
 
 impl HerdrApi for HerdrClient {
     fn pane_get(&self, pane_id: &str) -> Result<PaneInfo, HerdrError> {
         HerdrClient::pane_get(self, pane_id)
+    }
+
+    fn notification_show(&self, title: &str, body: &str, sound: &str) -> Result<(), HerdrError> {
+        HerdrClient::notification_show(self, title, body, sound)
     }
 
     fn pane_run(&self, pane_id: &str, input: &str) -> Result<(), HerdrError> {
@@ -134,10 +149,16 @@ impl HerdrApi for HerdrClient {
 
 pub fn msg_command(args: &[String]) -> Result<(), MsgError> {
     let arguments = parse_msg_arguments(args)?;
+    if arguments.attention && arguments.target != "god" {
+        return Err(MsgError::AttentionTarget);
+    }
     let run = select_run(arguments.run_dir.as_deref())?;
     let launchers = load_launchers()?;
     let herdr = HerdrClient::from_env();
     send_message(&run, &launchers, &arguments.target, &arguments.text, &herdr)?;
+    if arguments.attention {
+        request_attention(&run, &arguments.target, &arguments.text, &herdr)?;
+    }
     Ok(())
 }
 
@@ -163,10 +184,16 @@ pub(crate) fn deliver_queued_message(
 fn parse_msg_arguments(args: &[String]) -> Result<MsgArguments, MsgError> {
     let mut positional = Vec::new();
     let mut run_dir = None;
+    let mut attention = false;
     let mut index = 0;
 
     while index < args.len() {
-        if args[index] == "--run" {
+        if args[index] == "--attention" {
+            if attention {
+                return Err(arguments("--attention may only be supplied once"));
+            }
+            attention = true;
+        } else if args[index] == "--run" {
             if run_dir.is_some() {
                 return Err(arguments("--run may only be supplied once"));
             }
@@ -193,7 +220,52 @@ fn parse_msg_arguments(args: &[String]) -> Result<MsgArguments, MsgError> {
         target: positional.remove(0),
         text: positional.remove(0),
         run_dir,
+        attention,
     })
+}
+
+fn request_attention<H: HerdrApi>(
+    run: &RunBoard,
+    target: &str,
+    text: &str,
+    herdr: &H,
+) -> Result<(), MsgError> {
+    if target != "god" {
+        return Err(MsgError::AttentionTarget);
+    }
+    let source_pane = env::var("HERDR_PANE_ID").map_err(|_| MsgError::AttentionSource)?;
+    request_attention_from_pane(run, text, &source_pane, herdr)
+}
+
+fn request_attention_from_pane<H: HerdrApi>(
+    run: &RunBoard,
+    text: &str,
+    source_pane: &str,
+    herdr: &H,
+) -> Result<(), MsgError> {
+    let worker_name = run
+        .state
+        .workers
+        .iter()
+        .find_map(|(name, worker)| {
+            (worker.pane_id.as_deref() == Some(source_pane)).then(|| name.clone())
+        })
+        .ok_or(MsgError::AttentionSource)?;
+    let mut metadata = load_hook_metadata(&run.dir)?;
+    metadata.attention_pending.insert(worker_name.clone(), true);
+    let first = metadata
+        .aggregate_notifications
+        .insert(format!("attention:{worker_name}"), true)
+        .is_none();
+    save_run_with_hook(run, &metadata)?;
+    if first {
+        herdr.notification_show(
+            "Worker needs attention",
+            &format!("{worker_name}: {}", strip_escape_sequences(text)),
+            "request",
+        )?;
+    }
+    Ok(())
 }
 
 fn arguments(detail: impl AsRef<str>) -> MsgError {
@@ -535,6 +607,7 @@ mod tests {
         PaneGet(String),
         PaneRun(String, String),
         AgentWait(String, String),
+        Notification(String, String, String),
     }
 
     struct FakeHerdr {
@@ -600,6 +673,20 @@ mod tests {
                 .borrow_mut()
                 .pop_front()
                 .unwrap_or(WaitOutcome::Reached))
+        }
+
+        fn notification_show(
+            &self,
+            title: &str,
+            body: &str,
+            sound: &str,
+        ) -> Result<(), HerdrError> {
+            self.calls.borrow_mut().push(Call::Notification(
+                title.to_owned(),
+                body.to_owned(),
+                sound.to_owned(),
+            ));
+            Ok(())
         }
     }
 
@@ -829,6 +916,7 @@ mod tests {
                 target: "builder".to_owned(),
                 text: "hello".to_owned(),
                 run_dir: Some(PathBuf::from("/tmp/run")),
+                attention: false,
             }
         );
         assert!(parse_msg_arguments(&["builder".to_owned()]).is_err());
@@ -838,6 +926,37 @@ mod tests {
             "--run".to_owned(),
         ])
         .is_err());
+    }
+
+    #[test]
+    fn attention_request_notifies_once_and_persists_a_metadata_ping() {
+        let temp = TempDir::new();
+        let run = crate::run::create_run(
+            temp.path(),
+            fixture_run(temp.path(), "builder", "claude").state,
+        )
+        .expect("persist attention fixture");
+        let herdr = FakeHerdr::new("claude", Some("working"), []);
+
+        request_attention_from_pane(&run, "please review", "worker-pane", &herdr)
+            .expect("first attention request");
+        request_attention_from_pane(&run, "please review", "worker-pane", &herdr)
+            .expect("repeat attention request");
+
+        assert_eq!(
+            herdr
+                .calls()
+                .iter()
+                .filter(|call| matches!(call, Call::Notification(..)))
+                .count(),
+            1,
+        );
+        let metadata = crate::run::load_hook_metadata(&run.dir).expect("load persisted attention");
+        assert_eq!(metadata.attention_pending.get("builder"), Some(&true));
+        assert_eq!(
+            metadata.aggregate_notifications.get("attention:builder"),
+            Some(&true)
+        );
     }
 
     #[test]

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -67,6 +67,7 @@ pub enum ReconciliationAction {
         worker_name: String,
         status: String,
         sequence: u64,
+        attention: bool,
     },
     Notify {
         title: String,
@@ -91,6 +92,8 @@ pub struct HookMetadata {
     pub metadata_sequence: BTreeMap<String, u64>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub blocked_since_ms: BTreeMap<String, u64>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub attention_pending: BTreeMap<String, bool>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub aggregate_notifications: BTreeMap<String, bool>,
 }
@@ -159,6 +162,13 @@ pub fn reconcile_at(
     match event {
         IncomingEvent::AgentStatusChanged { status, .. } => {
             let Target::Worker(worker_name) = target else {
+                sweep_blocked_workers(
+                    &state,
+                    &mut metadata,
+                    &mut actions,
+                    now_ms,
+                    blocked_threshold_ms,
+                );
                 return Reconciliation {
                     state,
                     metadata,
@@ -177,10 +187,12 @@ pub fn reconcile_at(
                 .entry(worker_name.clone())
                 .or_insert(0);
             *sequence += 1;
+            let attention = metadata.attention_pending.remove(&worker_name).is_some();
             actions.push(ReconciliationAction::PublishMetadata {
                 worker_name: worker_name.clone(),
                 status: status.clone(),
                 sequence: *sequence,
+                attention,
             });
             if status == "idle" || status == "done" {
                 actions.push(ReconciliationAction::DrainOutbox {
@@ -197,35 +209,12 @@ pub fn reconcile_at(
                 });
             }
             if status == "blocked" {
-                let blocked_since = metadata
+                metadata
                     .blocked_since_ms
                     .entry(worker_name.clone())
                     .or_insert(now_ms);
-                if now_ms.saturating_sub(*blocked_since) >= blocked_threshold_ms {
-                    notify_once(
-                        &mut metadata,
-                        &mut actions,
-                        format!("blocked:{worker_name}"),
-                        "Worker blocked",
-                        format!(
-                            "{} has remained blocked beyond the configured threshold.",
-                            worker_name
-                        ),
-                        "request",
-                    );
-                }
             } else {
                 metadata.blocked_since_ms.remove(&worker_name);
-            }
-            if status == "needs_attention" {
-                notify_once(
-                    &mut metadata,
-                    &mut actions,
-                    format!("attention:{worker_name}"),
-                    "Worker needs attention",
-                    format!("{} explicitly requested attention.", worker_name),
-                    "request",
-                );
             }
             if state.workers.keys().all(|name| {
                 matches!(
@@ -306,6 +295,13 @@ pub fn reconcile_at(
         }
         IncomingEvent::PaneAgentDetected { agent, .. } => {
             let Target::Worker(worker_name) = target else {
+                sweep_blocked_workers(
+                    &state,
+                    &mut metadata,
+                    &mut actions,
+                    now_ms,
+                    blocked_threshold_ms,
+                );
                 return Reconciliation {
                     state,
                     metadata,
@@ -321,10 +317,42 @@ pub fn reconcile_at(
         }
     }
 
+    sweep_blocked_workers(
+        &state,
+        &mut metadata,
+        &mut actions,
+        now_ms,
+        blocked_threshold_ms,
+    );
+
     Reconciliation {
         state,
         metadata,
         actions,
+    }
+}
+
+fn sweep_blocked_workers(
+    state: &RunState,
+    metadata: &mut HookMetadata,
+    actions: &mut Vec<ReconciliationAction>,
+    now_ms: u64,
+    blocked_threshold_ms: u64,
+) {
+    for (worker_name, blocked_since) in metadata.blocked_since_ms.clone() {
+        if now_ms.saturating_sub(blocked_since) >= blocked_threshold_ms {
+            notify_once(
+                metadata,
+                actions,
+                format!("blocked:{worker_name}"),
+                "Worker blocked",
+                format!(
+                    "{worker_name} has remained blocked beyond the configured threshold in {}.",
+                    state.spec.name
+                ),
+                "request",
+            );
+        }
     }
 }
 
@@ -595,25 +623,12 @@ mod tests {
             0,
         );
 
-        let attention = reconcile(
-            &IncomingEvent::AgentStatusChanged {
-                pane_id: "pane-1".into(),
-                status: "needs_attention".into(),
-            },
-            repeated_blocked.state,
-            repeated_blocked.metadata,
-        );
-        assert!(attention
-            .metadata
-            .aggregate_notifications
-            .contains_key("attention:builder"));
-
         let exited = reconcile(
             &IncomingEvent::PaneExited {
                 pane_id: "pane-1".into(),
             },
-            attention.state,
-            attention.metadata,
+            repeated_blocked.state,
+            repeated_blocked.metadata,
         );
         let repeated_exit = reconcile(
             &IncomingEvent::PaneExited {
@@ -697,5 +712,54 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn unrelated_worker_event_sweeps_blocked_duration() {
+        let mut two_workers = state();
+        two_workers.spec.workers.push(WorkerSpec {
+            name: "reviewer".to_owned(),
+            agent: "claude".to_owned(),
+            role: "review".to_owned(),
+            worktree: false,
+            branch: None,
+            brief: PathBuf::from("review.md"),
+        });
+        two_workers.workers.insert(
+            "reviewer".to_owned(),
+            WorkerRunState {
+                workspace_id: Some("workspace-2".to_owned()),
+                pane_id: Some("pane-2".to_owned()),
+                agent_id: None,
+                agent_session: None,
+                worktree_path: None,
+                adopted: false,
+                lifecycle: WorkerLifecycle::Running,
+            },
+        );
+        let blocked = reconcile_at(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "blocked".into(),
+            },
+            two_workers,
+            HookMetadata::default(),
+            100,
+            1_000,
+        );
+        let later_reviewer_event = reconcile_at(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-2".into(),
+                status: "working".into(),
+            },
+            blocked.state,
+            blocked.metadata,
+            1_100,
+            1_000,
+        );
+        assert!(later_reviewer_event.actions.iter().any(|action| matches!(
+            action,
+            ReconciliationAction::Notify { title, .. } if title == "Worker blocked"
+        )));
     }
 }

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -1,5 +1,6 @@
 //! Pure hook event reconciliation for the run-board.
 
+use crate::metadata::MetadataCapabilities;
 use crate::types::{RunLifecycle, RunState, WorkerLifecycle};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -38,14 +39,40 @@ pub enum IncomingEvent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReconciliationAction {
     RecordEvent,
-    TrackAgentStatus { worker_name: String, status: String },
-    InjectPointer { worker_name: String, status: String },
-    DrainOutbox { worker_name: String },
-    MigratePane { worker_name: String },
+    TrackAgentStatus {
+        worker_name: String,
+        status: String,
+    },
+    InjectPointer {
+        worker_name: String,
+        status: String,
+    },
+    DrainOutbox {
+        worker_name: String,
+    },
+    MigratePane {
+        worker_name: String,
+    },
     MigrateGodPane,
-    MarkWorkerOrphaned { worker_name: String },
-    EndWorker { worker_name: String },
-    BindAgentIdentity { worker_name: String },
+    MarkWorkerOrphaned {
+        worker_name: String,
+    },
+    EndWorker {
+        worker_name: String,
+    },
+    BindAgentIdentity {
+        worker_name: String,
+    },
+    PublishMetadata {
+        worker_name: String,
+        status: String,
+        sequence: u64,
+    },
+    Notify {
+        title: String,
+        body: String,
+        sound: String,
+    },
     EndRun,
 }
 
@@ -58,6 +85,14 @@ pub struct HookMetadata {
     pub worker_agent_identity: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub god_workspace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata_capabilities: Option<MetadataCapabilities>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata_sequence: BTreeMap<String, u64>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub blocked_since_ms: BTreeMap<String, u64>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub aggregate_notifications: BTreeMap<String, bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -68,10 +103,17 @@ pub struct Reconciliation {
 }
 
 /// Reconcile one event against one active run without I/O or process spawning.
-pub fn reconcile(
+pub fn reconcile(event: &IncomingEvent, state: RunState, metadata: HookMetadata) -> Reconciliation {
+    reconcile_at(event, state, metadata, 0, 0)
+}
+
+/// Pure reconciliation with an injected clock for the blocked-duration policy.
+pub fn reconcile_at(
     event: &IncomingEvent,
     mut state: RunState,
     mut metadata: HookMetadata,
+    now_ms: u64,
+    blocked_threshold_ms: u64,
 ) -> Reconciliation {
     let mut actions = Vec::new();
     let target = match event {
@@ -130,6 +172,16 @@ pub fn reconcile(
                 worker_name: worker_name.clone(),
                 status: status.clone(),
             });
+            let sequence = metadata
+                .metadata_sequence
+                .entry(worker_name.clone())
+                .or_insert(0);
+            *sequence += 1;
+            actions.push(ReconciliationAction::PublishMetadata {
+                worker_name: worker_name.clone(),
+                status: status.clone(),
+                sequence: *sequence,
+            });
             if status == "idle" || status == "done" {
                 actions.push(ReconciliationAction::DrainOutbox {
                     worker_name: worker_name.clone(),
@@ -140,9 +192,58 @@ pub fn reconcile(
                 || (status == "done" && previous.as_deref() == Some("working"))
             {
                 actions.push(ReconciliationAction::InjectPointer {
-                    worker_name,
+                    worker_name: worker_name.clone(),
                     status: status.clone(),
                 });
+            }
+            if status == "blocked" {
+                let blocked_since = metadata
+                    .blocked_since_ms
+                    .entry(worker_name.clone())
+                    .or_insert(now_ms);
+                if now_ms.saturating_sub(*blocked_since) >= blocked_threshold_ms {
+                    notify_once(
+                        &mut metadata,
+                        &mut actions,
+                        format!("blocked:{worker_name}"),
+                        "Worker blocked",
+                        format!(
+                            "{} has remained blocked beyond the configured threshold.",
+                            worker_name
+                        ),
+                        "request",
+                    );
+                }
+            } else {
+                metadata.blocked_since_ms.remove(&worker_name);
+            }
+            if status == "needs_attention" {
+                notify_once(
+                    &mut metadata,
+                    &mut actions,
+                    format!("attention:{worker_name}"),
+                    "Worker needs attention",
+                    format!("{} explicitly requested attention.", worker_name),
+                    "request",
+                );
+            }
+            if state.workers.keys().all(|name| {
+                matches!(
+                    metadata.worker_status.get(name).map(String::as_str),
+                    Some("idle" | "done")
+                )
+            }) {
+                notify_once(
+                    &mut metadata,
+                    &mut actions,
+                    "team-complete".to_owned(),
+                    "Team complete",
+                    format!(
+                        "All workers in {} reached a terminal status.",
+                        state.spec.name
+                    ),
+                    "done",
+                );
             }
         }
         IncomingEvent::PaneMoved {
@@ -174,7 +275,17 @@ pub fn reconcile(
                     .get_mut(&worker_name)
                     .expect("matched worker exists")
                     .lifecycle = WorkerLifecycle::Orphaned;
-                actions.push(ReconciliationAction::MarkWorkerOrphaned { worker_name });
+                actions.push(ReconciliationAction::MarkWorkerOrphaned {
+                    worker_name: worker_name.clone(),
+                });
+                notify_once(
+                    &mut metadata,
+                    &mut actions,
+                    format!("exit:{worker_name}"),
+                    "Worker exited",
+                    format!("{} exited before the team released it.", worker_name),
+                    "request",
+                );
                 end_run_if_no_live_workers(&mut state, &mut actions);
             }
             Target::God => end_run(&mut state, &mut actions),
@@ -214,6 +325,23 @@ pub fn reconcile(
         state,
         metadata,
         actions,
+    }
+}
+
+fn notify_once(
+    metadata: &mut HookMetadata,
+    actions: &mut Vec<ReconciliationAction>,
+    key: String,
+    title: &str,
+    body: String,
+    sound: &str,
+) {
+    if metadata.aggregate_notifications.insert(key, true).is_none() {
+        actions.push(ReconciliationAction::Notify {
+            title: title.to_owned(),
+            body,
+            sound: sound.to_owned(),
+        });
     }
 }
 
@@ -421,6 +549,153 @@ mod tests {
             .state
             .lifecycle,
             RunLifecycle::Ended
+        );
+    }
+
+    #[test]
+    fn metadata_sequences_and_aggregate_notifications_are_at_most_once() {
+        let working = reconcile(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "working".into(),
+            },
+            state(),
+            HookMetadata::default(),
+        );
+        let blocked = reconcile(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "blocked".into(),
+            },
+            working.state,
+            working.metadata,
+        );
+        let repeated_blocked = reconcile(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "blocked".into(),
+            },
+            blocked.state,
+            blocked.metadata,
+        );
+        assert_eq!(repeated_blocked.metadata.metadata_sequence["builder"], 3);
+        assert_eq!(
+            repeated_blocked
+                .metadata
+                .aggregate_notifications
+                .get("blocked:builder"),
+            Some(&true),
+        );
+        assert_eq!(
+            repeated_blocked
+                .actions
+                .iter()
+                .filter(|action| matches!(action, ReconciliationAction::Notify { .. }))
+                .count(),
+            0,
+        );
+
+        let attention = reconcile(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "needs_attention".into(),
+            },
+            repeated_blocked.state,
+            repeated_blocked.metadata,
+        );
+        assert!(attention
+            .metadata
+            .aggregate_notifications
+            .contains_key("attention:builder"));
+
+        let exited = reconcile(
+            &IncomingEvent::PaneExited {
+                pane_id: "pane-1".into(),
+            },
+            attention.state,
+            attention.metadata,
+        );
+        let repeated_exit = reconcile(
+            &IncomingEvent::PaneExited {
+                pane_id: "pane-1".into(),
+            },
+            exited.state,
+            exited.metadata,
+        );
+        assert!(repeated_exit
+            .metadata
+            .aggregate_notifications
+            .contains_key("exit:builder"));
+        assert_eq!(
+            repeated_exit
+                .actions
+                .iter()
+                .filter(|action| matches!(action, ReconciliationAction::Notify { .. }))
+                .count(),
+            0,
+        );
+
+        let completed = reconcile(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "idle".into(),
+            },
+            state(),
+            HookMetadata::default(),
+        );
+        assert!(completed
+            .metadata
+            .aggregate_notifications
+            .contains_key("team-complete"));
+    }
+
+    #[test]
+    fn blocked_notification_waits_for_the_configured_duration() {
+        let first = reconcile_at(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "blocked".into(),
+            },
+            state(),
+            HookMetadata::default(),
+            100,
+            1_000,
+        );
+        assert!(!first
+            .actions
+            .iter()
+            .any(|action| matches!(action, ReconciliationAction::Notify { .. })));
+        let before_threshold = reconcile_at(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "blocked".into(),
+            },
+            first.state,
+            first.metadata,
+            1_099,
+            1_000,
+        );
+        assert!(!before_threshold
+            .actions
+            .iter()
+            .any(|action| matches!(action, ReconciliationAction::Notify { .. })));
+        let elapsed = reconcile_at(
+            &IncomingEvent::AgentStatusChanged {
+                pane_id: "pane-1".into(),
+                status: "blocked".into(),
+            },
+            before_threshold.state,
+            before_threshold.metadata,
+            1_100,
+            1_000,
+        );
+        assert_eq!(
+            elapsed
+                .actions
+                .iter()
+                .filter(|action| matches!(action, ReconciliationAction::Notify { .. }))
+                .count(),
+            1
         );
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -122,6 +122,22 @@ pub fn save_run_with_hook(run: &RunBoard, hook: &HookMetadata) -> Result<(), Run
             contents.push_str("\n[hook.worker_agent_identity]\n");
             contents.push_str(&toml::to_string(&hook.worker_agent_identity)?);
         }
+        if let Some(capabilities) = &hook.metadata_capabilities {
+            contents.push_str("\n[hook.metadata_capabilities]\n");
+            contents.push_str(&toml::to_string(capabilities)?);
+        }
+        if !hook.metadata_sequence.is_empty() {
+            contents.push_str("\n[hook.metadata_sequence]\n");
+            contents.push_str(&toml::to_string(&hook.metadata_sequence)?);
+        }
+        if !hook.blocked_since_ms.is_empty() {
+            contents.push_str("\n[hook.blocked_since_ms]\n");
+            contents.push_str(&toml::to_string(&hook.blocked_since_ms)?);
+        }
+        if !hook.aggregate_notifications.is_empty() {
+            contents.push_str("\n[hook.aggregate_notifications]\n");
+            contents.push_str(&toml::to_string(&hook.aggregate_notifications)?);
+        }
     }
     write_run_contents(&run.dir, &contents)
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -134,6 +134,10 @@ pub fn save_run_with_hook(run: &RunBoard, hook: &HookMetadata) -> Result<(), Run
             contents.push_str("\n[hook.blocked_since_ms]\n");
             contents.push_str(&toml::to_string(&hook.blocked_since_ms)?);
         }
+        if !hook.attention_pending.is_empty() {
+            contents.push_str("\n[hook.attention_pending]\n");
+            contents.push_str(&toml::to_string(&hook.attention_pending)?);
+        }
         if !hook.aggregate_notifications.is_empty() {
             contents.push_str("\n[hook.aggregate_notifications]\n");
             contents.push_str(&toml::to_string(&hook.aggregate_notifications)?);


### PR DESCRIPTION
## Summary
- schema-gate and persist source-scoped worker metadata with per-worker sequence numbers
- emit once-only aggregate team, blocked-duration, exit, and worker-requested attention notifications
- document the live 0.7.3 mapping and Codex coexistence probe

## Review fixes
- `msg god <text> --attention` is now the production explicit-attention path: it identifies the source worker with `HERDR_PANE_ID`, persists a pending TTL metadata ping, and emits one notification.
- Blocked-duration notifications now sweep every persisted blocked worker on each matching run event, so another worker activity can trigger the threshold.

## Coexistence probe
On live herdr 0.7.3, `--source caioniehues:herdr-agent-team` metadata round-tripped on an active Codex pane while native `agent=codex` and `agent_status=working` remained unchanged. `--applies-to-source herdr:codex` produced no visible update despite the pane session source, so this implementation intentionally omits that restrictive filter and never calls `pane report-agent`.

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (123 passed)

Closes #6.