### PR TITLE
feat: add team control deck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,57 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -18,6 +65,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 name = "herdr-agent-team"
 version = "0.5.0"
 dependencies = [
+ "crossterm",
  "serde",
  "serde_json",
  "thiserror",
@@ -41,10 +89,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -63,6 +173,34 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -115,6 +253,43 @@ checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "syn"
@@ -191,6 +366,122 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Herdr plugin: heterogeneous coding-agent teams under a coordinati
 repository = "https://github.com/caioniehues/herdr-agent-team"
 
 [dependencies]
+crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ of polling.
   to the god. Mesh: workers also get a peer table and message each other through
   the same `msg` verb with a structured envelope.
 
+## Team control deck
+
+Open the native board as a durable tab with the `open-board` plugin action (or
+open the `board` pane with an `overlay` placement for a quick popup). It polls
+the newest active run by default, keeping collection outside its render tick.
+Use `j`/`k` to select a worker; `m` sends a message, `g` acknowledges attention,
+`K` kills only that worker, `o` opens its `report:` link, and `p` adopts a pane.
+
+Example Herdr keybinding:
+
+```toml
+[[keys.command]]
+key = "prefix+b"
+type = "plugin_action"
+command = "caioniehues.agent-team.open-board"
+description = "open agent-team control deck"
+```
+
 ## Why
 
 Nothing on the Herdr marketplace orchestrates *heterogeneous* agent teams. The

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -162,14 +162,20 @@ Given a spec (file or shorthand):
   kind, herdr status, last report time. `--json` for the god.
 - `kill`: close team workspaces (`herdr workspace close`), optionally
   `--remove-worktrees` (refuses if worktree dirty — salvage rule), mark run
-  ended in `run.toml`.
+  ended in `run.toml`. `kill <run-dir> --worker <name>` tears down only that
+  owned workspace (or releases an adopted pane), retains the run while other
+  workers remain, and keeps the same dirty-worktree refusal.
 
-## 7. Manifest surface (v1)
+## 7. Manifest surface
 
-- `[[actions]]`: `spawn` (context: workspace), `status`, `kill` — thin wrappers
-  over the binary for keybinding/palette use. The god calls the binary directly.
+- `[[actions]]`: `spawn` (context: workspace), `status`, `kill`, and
+  `open-board` — thin wrappers over the binary for keybinding/palette use.
 - `[[events]]`: agent status change → `<binary> on-agent-status`.
-- No `[[panes]]` in v1 (dashboard is v1.1+), no link handlers.
+- `[[panes]] board`: a durable tab control deck; callers may override placement
+  to `overlay` for a quick popup. `[[link_handlers]] report` routes `report:`
+  pointers to `open-report` using `HERDR_PLUGIN_CLICKED_URL`.
+- A user keybind uses `type = "plugin_action"` and command
+  `caioniehues.agent-team.open-board`.
 
 ## 8. Post-v1 roadmap (rewritten 2026-07-15 from the research wave)
 
@@ -205,18 +211,19 @@ feature.
    ordinary status flip. `HERDR_AGENT_TEAM_BLOCKED_THRESHOLD_MS` configures
    the blocked-duration policy (default: five minutes; checked on subsequent
    lifecycle/status events because this plugin has no daemon).
-4. **Native board pane — repurposed 2026-07-15 (issue #7 comment, after
+4. **Native board pane — SHIPPED (#7, 2026-07-15): repurposed 2026-07-15 (issue #7 comment, after
    prototype round 1): the human's CONTROL DECK for the god's team, not a
    status dashboard.** Per-worker row actions are first-class — msg worker,
    ack/answer attention, kill worker, adopt pane, open report — issued from
    the board without interrupting the god session (`[[panes]]` entrypoint
    with durable tab + popup variant, `open-board` action, `plugin_action`
    keybinds, link handler making report/task pointers hot). Informational
-   core = run-scoped facts nothing else renders: tasks, dependencies (source
-   to be defined by the ticket — the run holds none today), report links,
+   core = run-scoped facts nothing else renders: optional tasks stored in the
+   worker spec and run state, report links,
    mailbox state. Status rendering stays minimal: one team strip; per-pane
    status belongs to the sidebar via step-3 metadata — never a generic
-   agent list.
+   agent list. Dependencies remain deferred. Collection is CLI polling behind
+   a small collector seam; #8 replaces it with socket snapshots/subscription.
 5. **Direct socket backend behind `HerdrApi`** (ADR-0011): snapshot +
    subscription for the board and aggregate `team wait
    [--until all|any|blocked|report]`; CLI stays default/fallback.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -26,6 +26,31 @@ title = "Kill team"
 contexts = ["workspace"]
 command = ["target/release/herdr-agent-team", "kill"]
 
+[[actions]]
+id = "open-board"
+title = "Open team control deck"
+contexts = ["workspace"]
+command = ["sh", "-c", "\"$HERDR_BIN_PATH\" plugin pane open --plugin caioniehues.agent-team --entrypoint board --placement tab"]
+
+[[actions]]
+id = "open-report"
+title = "Open team report"
+contexts = ["pane"]
+command = ["target/release/herdr-agent-team", "open-report"]
+
+[[panes]]
+id = "board"
+title = "Agent Team control deck"
+description = "Keyboard-driven worker controls; open as a tab or override placement for a quick popup."
+placement = "tab"
+command = ["target/release/herdr-agent-team", "board"]
+
+[[link_handlers]]
+id = "report"
+title = "Open team report"
+pattern = "^report:.+$"
+action = "open-report"
+
 # Report flow: worker status flips -> inbox append + pointer injection into the
 # god pane (ADR-0002). The manifest uses the live-verified dot-form event name;
 # HERDR_PLUGIN_EVENT_JSON uses the underscore form (spec section 9).

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -317,6 +317,7 @@ fn adopt_resolved<H: HerdrApi>(
         name: arguments.name,
         agent,
         role: arguments.role,
+        task: None,
         worktree: false,
         branch: None,
         brief: arguments.brief.clone().unwrap_or_default(),
@@ -456,6 +457,7 @@ fn insert_adopted_worker(state: &mut RunState, worker: &WorkerSpec, pane: &PaneI
     state.workers.insert(
         worker.name.clone(),
         WorkerRunState {
+            task: worker.task.clone(),
             workspace_id: Some(pane.workspace_id.clone()),
             pane_id: Some(pane.pane_id.clone()),
             agent_id: pane.agent_id.clone(),
@@ -621,6 +623,7 @@ mod tests {
             name: "existing".to_owned(),
             agent: "claude".to_owned(),
             role: "existing worker".to_owned(),
+            task: None,
             worktree: false,
             branch: None,
             brief: root.join("existing.md"),
@@ -641,6 +644,7 @@ mod tests {
                 workers: BTreeMap::from([(
                     "existing".to_owned(),
                     WorkerRunState {
+                        task: None,
                         workspace_id: Some("workspace-existing".to_owned()),
                         pane_id: Some("pane-existing".to_owned()),
                         agent_id: Some("session-existing".to_owned()),

--- a/src/agents_md.rs
+++ b/src/agents_md.rs
@@ -199,6 +199,7 @@ mod tests {
             name: name.to_owned(),
             agent: "codex".to_owned(),
             role: role.to_owned(),
+            task: None,
             worktree,
             branch: worktree.then(|| format!("feat/{name}")),
             brief: PathBuf::from(format!("briefs/{name}.md")),
@@ -220,6 +221,7 @@ mod tests {
             workers,
         };
         let worker_state = |workspace_id: &str, worktree_path: Option<&str>| WorkerRunState {
+            task: None,
             workspace_id: Some(workspace_id.to_owned()),
             pane_id: Some(format!("{workspace_id}-pane")),
             agent_id: None,

--- a/src/board.rs
+++ b/src/board.rs
@@ -1,0 +1,503 @@
+//! Keyboard-driven human control deck (spec section 8, roadmap step 4).
+
+use crate::run::{list_active_runs, load_run, RunError};
+use crate::types::WorkerLifecycle;
+use crossterm::{
+    cursor,
+    event::{self, Event, KeyCode},
+    execute,
+    terminal::{self, ClearType},
+};
+use std::env;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+use thiserror::Error;
+
+const BOARD_USAGE: &str = "usage: herdr-agent-team board [--run <run-dir>]";
+
+#[derive(Debug, Error)]
+pub enum BoardError {
+    #[error("{0}")]
+    Usage(String),
+    #[error(transparent)]
+    Run(#[from] RunError),
+    #[error("cannot read board inbox {path}: {source}")]
+    Inbox { path: PathBuf, source: io::Error },
+    #[error("cannot enter board terminal mode: {0}")]
+    Terminal(#[from] io::Error),
+    #[error("no active team run found under {0}")]
+    NoActiveRun(PathBuf),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoardWorker {
+    pub name: String,
+    pub lifecycle: WorkerLifecycle,
+    pub pane_id: Option<String>,
+    pub task: Option<String>,
+    pub report: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoardSnapshot {
+    pub team: String,
+    pub run_dir: PathBuf,
+    pub lifecycle: String,
+    pub workers: Vec<BoardWorker>,
+    pub mailbox_events: usize,
+}
+
+/// Collection stays behind this seam so socket snapshots can replace polling in #8.
+pub trait BoardCollector {
+    fn collect(&self) -> Result<BoardSnapshot, BoardError>;
+}
+
+pub struct RunCollector {
+    pub run_dir: PathBuf,
+}
+
+impl BoardCollector for RunCollector {
+    fn collect(&self) -> Result<BoardSnapshot, BoardError> {
+        collect_run(&self.run_dir)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoardKey {
+    Up,
+    Down,
+    Msg,
+    Acknowledge,
+    Kill,
+    Open,
+    Adopt,
+    Quit,
+    Refresh,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoardAction {
+    Msg { worker: String },
+    Acknowledge { worker: String },
+    Kill { worker: String },
+    Open { report: Option<PathBuf> },
+    Adopt,
+    Quit,
+    Refresh,
+    None,
+}
+
+pub fn apply_key(selection: &mut usize, worker_count: usize, key: BoardKey) -> BoardAction {
+    if worker_count == 0 {
+        return if key == BoardKey::Quit {
+            BoardAction::Quit
+        } else {
+            BoardAction::None
+        };
+    }
+    match key {
+        BoardKey::Down => {
+            *selection = (*selection + 1) % worker_count;
+            BoardAction::None
+        }
+        BoardKey::Up => {
+            *selection = (*selection + worker_count - 1) % worker_count;
+            BoardAction::None
+        }
+        BoardKey::Msg => BoardAction::Msg {
+            worker: String::new(),
+        },
+        BoardKey::Acknowledge => BoardAction::Acknowledge {
+            worker: String::new(),
+        },
+        BoardKey::Kill => BoardAction::Kill {
+            worker: String::new(),
+        },
+        BoardKey::Open => BoardAction::Open { report: None },
+        BoardKey::Adopt => BoardAction::Adopt,
+        BoardKey::Quit => BoardAction::Quit,
+        BoardKey::Refresh => BoardAction::Refresh,
+        BoardKey::Other => BoardAction::None,
+    }
+}
+
+pub fn action_args(
+    action: &BoardAction,
+    run_dir: &Path,
+    text: Option<&str>,
+    pane: Option<&str>,
+    name: Option<&str>,
+) -> Option<Vec<String>> {
+    let run = run_dir.display().to_string();
+    match action {
+        BoardAction::Msg { worker } => Some(vec![
+            "msg".into(),
+            worker.clone(),
+            text.unwrap_or_default().into(),
+            "--run".into(),
+            run,
+        ]),
+        BoardAction::Acknowledge { worker } => Some(vec![
+            "msg".into(),
+            worker.clone(),
+            "acknowledged".into(),
+            "--run".into(),
+            run,
+        ]),
+        BoardAction::Kill { worker } => {
+            Some(vec!["kill".into(), run, "--worker".into(), worker.clone()])
+        }
+        BoardAction::Adopt => Some(vec![
+            "adopt".into(),
+            pane.unwrap_or_default().into(),
+            "--name".into(),
+            name.unwrap_or_default().into(),
+            "--run".into(),
+            run,
+        ]),
+        _ => None,
+    }
+}
+
+pub fn render(snapshot: &BoardSnapshot, selection: usize) -> String {
+    let mut output = format!(" BOARD · {} · {} · {} workers\n\n     WORKER       STATE      PANE      TASK                       REPORT\n", snapshot.team, snapshot.lifecycle, snapshot.workers.len());
+    for (index, worker) in snapshot.workers.iter().enumerate() {
+        let marker = if index == selection { " ▶ " } else { "   " };
+        let report = worker
+            .report
+            .as_ref()
+            .map(|path| format!("report:{}", path.display()))
+            .unwrap_or_else(|| "-".into());
+        output.push_str(&format!(
+            "{marker}{} {:<12} {:<10} {:<9} {:<26} {report}\n",
+            glyph(worker.lifecycle),
+            worker.name,
+            lifecycle_name(worker.lifecycle),
+            worker.pane_id.as_deref().unwrap_or("-"),
+            worker.task.as_deref().unwrap_or("")
+        ));
+    }
+    output.push_str(&format!("\n team {}   mailbox: {} events\n────────────────────────────────────────────────────────\n [j/k] select  [m] msg  [g] ack  [K] kill  [o] open report  [p] adopt  [q] quit\n", team_strip(&snapshot.workers), snapshot.mailbox_events));
+    output
+}
+
+pub fn board_command(args: &[String]) -> Result<(), BoardError> {
+    let run_dir = select_run(args)?;
+    run_board(RunCollector { run_dir })
+}
+
+pub fn open_report_command(args: &[String]) -> Result<(), BoardError> {
+    let path = if let Ok(url) = env::var("HERDR_PLUGIN_CLICKED_URL") {
+        PathBuf::from(url.trim_start_matches("report:"))
+    } else {
+        args.first().map(PathBuf::from).ok_or_else(|| {
+            BoardError::Usage("usage: herdr-agent-team open-report <report-path>".into())
+        })?
+    };
+    open_report(&path);
+    Ok(())
+}
+
+fn select_run(args: &[String]) -> Result<PathBuf, BoardError> {
+    let state_dir = env::var_os("HERDR_PLUGIN_STATE_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    match args {
+        [] => list_active_runs(&state_dir)?
+            .pop()
+            .map(|run| run.dir)
+            .ok_or(BoardError::NoActiveRun(state_dir)),
+        [flag, path] if flag == "--run" => Ok(PathBuf::from(path)),
+        _ => Err(BoardError::Usage(BOARD_USAGE.into())),
+    }
+}
+
+fn collect_run(run_dir: &Path) -> Result<BoardSnapshot, BoardError> {
+    let run = load_run(run_dir)?;
+    let mailbox = run.dir.join("inbox").join("events.jsonl");
+    let mailbox_events = match fs::read_to_string(&mailbox) {
+        Ok(events) => events.lines().count(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => 0,
+        Err(source) => {
+            return Err(BoardError::Inbox {
+                path: mailbox,
+                source,
+            })
+        }
+    };
+    let workers = run
+        .state
+        .spec
+        .workers
+        .iter()
+        .map(|spec| {
+            let state = run
+                .state
+                .workers
+                .get(&spec.name)
+                .expect("run states are keyed by spec worker");
+            let report_path = run.dir.join("inbox").join(format!("{}.md", spec.name));
+            BoardWorker {
+                name: spec.name.clone(),
+                lifecycle: state.lifecycle,
+                pane_id: state.pane_id.clone(),
+                task: state.task.clone().or_else(|| spec.task.clone()),
+                report: report_path.is_file().then_some(report_path),
+            }
+        })
+        .collect();
+    Ok(BoardSnapshot {
+        team: run.state.spec.name,
+        run_dir: run.dir,
+        lifecycle: format!("{:?}", run.state.lifecycle).to_lowercase(),
+        workers,
+        mailbox_events,
+    })
+}
+
+fn run_board(collector: impl BoardCollector) -> Result<(), BoardError> {
+    let mut stdout = io::stdout();
+    let mut selection = 0;
+    let mut snapshot = collector.collect()?;
+    terminal::enable_raw_mode()?;
+    let result = (|| -> Result<(), BoardError> {
+        loop {
+            selection %= snapshot.workers.len().max(1);
+            execute!(
+                stdout,
+                terminal::Clear(ClearType::All),
+                cursor::MoveTo(0, 0)
+            )?;
+            print!("{}", render(&snapshot, selection));
+            stdout.flush()?;
+            if !event::poll(Duration::from_secs(2))? {
+                snapshot = collector.collect()?;
+                continue;
+            }
+            let Event::Key(key) = event::read()? else {
+                continue;
+            };
+            let raw_action = apply_key(
+                &mut selection,
+                snapshot.workers.len(),
+                key_from_code(key.code),
+            );
+            let action = bind_worker(raw_action, snapshot.workers.get(selection));
+            match action {
+                BoardAction::Quit => break,
+                BoardAction::Refresh | BoardAction::None => {}
+                BoardAction::Open { report: Some(path) } => {
+                    terminal::disable_raw_mode()?;
+                    open_report(&path);
+                    terminal::enable_raw_mode()?;
+                }
+                BoardAction::Open { report: None } => {}
+                action => {
+                    terminal::disable_raw_mode()?;
+                    execute_action(&action, &snapshot.run_dir)?;
+                    terminal::enable_raw_mode()?;
+                }
+            }
+            snapshot = collector.collect()?;
+        }
+        Ok(())
+    })();
+    terminal::disable_raw_mode()?;
+    result
+}
+
+fn bind_worker(action: BoardAction, worker: Option<&BoardWorker>) -> BoardAction {
+    let Some(worker) = worker else { return action };
+    match action {
+        BoardAction::Msg { .. } => BoardAction::Msg {
+            worker: worker.name.clone(),
+        },
+        BoardAction::Acknowledge { .. } => BoardAction::Acknowledge {
+            worker: worker.name.clone(),
+        },
+        BoardAction::Kill { .. } => BoardAction::Kill {
+            worker: worker.name.clone(),
+        },
+        BoardAction::Open { .. } => BoardAction::Open {
+            report: worker.report.clone(),
+        },
+        other => other,
+    }
+}
+
+fn execute_action(action: &BoardAction, run_dir: &Path) -> Result<(), BoardError> {
+    let (text, pane, name) = match action {
+        BoardAction::Msg { .. } => (Some(prompt("message: ")?), None, None),
+        BoardAction::Adopt => (
+            None,
+            Some(prompt("pane id: ")?),
+            Some(prompt("worker name: ")?),
+        ),
+        _ => (None, None, None),
+    };
+    let Some(args) = action_args(
+        action,
+        run_dir,
+        text.as_deref(),
+        pane.as_deref(),
+        name.as_deref(),
+    ) else {
+        return Ok(());
+    };
+    let status = Command::new(env::current_exe().map_err(BoardError::Terminal)?)
+        .args(args)
+        .status()
+        .map_err(BoardError::Terminal)?;
+    if !status.success() {
+        eprintln!("board action failed: {status}");
+    }
+    Ok(())
+}
+
+fn prompt(label: &str) -> Result<String, BoardError> {
+    print!("{label}");
+    io::stdout().flush()?;
+    let mut value = String::new();
+    io::stdin().read_line(&mut value)?;
+    Ok(value.trim().to_owned())
+}
+fn open_report(path: &Path) {
+    let pager = env::var("PAGER").unwrap_or_else(|_| "less".into());
+    let _ = Command::new(pager).arg(path).status();
+}
+fn key_from_code(code: KeyCode) -> BoardKey {
+    match code {
+        KeyCode::Char('j') | KeyCode::Down => BoardKey::Down,
+        KeyCode::Char('k') | KeyCode::Up => BoardKey::Up,
+        KeyCode::Char('m') => BoardKey::Msg,
+        KeyCode::Char('g') => BoardKey::Acknowledge,
+        KeyCode::Char('K') => BoardKey::Kill,
+        KeyCode::Char('o') => BoardKey::Open,
+        KeyCode::Char('p') => BoardKey::Adopt,
+        KeyCode::Char('q') | KeyCode::Esc => BoardKey::Quit,
+        KeyCode::Char('r') => BoardKey::Refresh,
+        _ => BoardKey::Other,
+    }
+}
+fn glyph(state: WorkerLifecycle) -> char {
+    match state {
+        WorkerLifecycle::Running => '●',
+        WorkerLifecycle::Pending => '◌',
+        WorkerLifecycle::Ended => '○',
+        WorkerLifecycle::Released => '◇',
+        WorkerLifecycle::Failed | WorkerLifecycle::Orphaned => '✖',
+    }
+}
+fn lifecycle_name(state: WorkerLifecycle) -> &'static str {
+    match state {
+        WorkerLifecycle::Pending => "pending",
+        WorkerLifecycle::Running => "running",
+        WorkerLifecycle::Failed => "failed",
+        WorkerLifecycle::Ended => "ended",
+        WorkerLifecycle::Released => "released",
+        WorkerLifecycle::Orphaned => "orphaned",
+    }
+}
+fn team_strip(workers: &[BoardWorker]) -> String {
+    workers
+        .iter()
+        .map(|worker| glyph(worker.lifecycle).to_string())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn selection_wraps() {
+        let mut selected = 0;
+        apply_key(&mut selected, 2, BoardKey::Up);
+        assert_eq!(selected, 1);
+        apply_key(&mut selected, 2, BoardKey::Down);
+        assert_eq!(selected, 0);
+    }
+    #[test]
+    fn action_keys_map_to_exact_cli_arguments() {
+        let run = Path::new("/runs/team");
+        assert_eq!(
+            action_args(
+                &BoardAction::Kill { worker: "f".into() },
+                run,
+                None,
+                None,
+                None
+            ),
+            Some(
+                vec!["kill", "/runs/team", "--worker", "f"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect()
+            )
+        );
+        assert_eq!(
+            action_args(
+                &BoardAction::Msg { worker: "f".into() },
+                run,
+                Some("hello"),
+                None,
+                None
+            ),
+            Some(
+                vec!["msg", "f", "hello", "--run", "/runs/team"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect()
+            )
+        );
+        assert_eq!(
+            action_args(
+                &BoardAction::Acknowledge { worker: "f".into() },
+                run,
+                None,
+                None,
+                None
+            ),
+            Some(
+                vec!["msg", "f", "acknowledged", "--run", "/runs/team"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect()
+            )
+        );
+        assert_eq!(
+            action_args(&BoardAction::Adopt, run, None, Some("w1:p2"), Some("new")),
+            Some(
+                vec!["adopt", "w1:p2", "--name", "new", "--run", "/runs/team"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect()
+            )
+        );
+    }
+    #[test]
+    fn render_snapshot_has_table_strip_and_footer() {
+        let snapshot = BoardSnapshot {
+            team: "wave".into(),
+            run_dir: PathBuf::from("/run"),
+            lifecycle: "active".into(),
+            mailbox_events: 3,
+            workers: vec![BoardWorker {
+                name: "builder".into(),
+                lifecycle: WorkerLifecycle::Running,
+                pane_id: Some("w1:p2".into()),
+                task: Some("ship board".into()),
+                report: Some(PathBuf::from("/run/inbox/builder.md")),
+            }],
+        };
+        let output = render(&snapshot, 0);
+        assert!(output.contains("WORKER"));
+        assert!(output.contains("mailbox: 3 events"));
+        assert!(output.contains("[j/k] select"));
+        assert!(output.contains("report:/run/inbox/builder.md"));
+    }
+}

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -466,6 +466,7 @@ mod tests {
                         name: worker_name.clone(),
                         agent: "codex".to_owned(),
                         role: "builder".to_owned(),
+                        task: None,
                         worktree: false,
                         branch: None,
                         brief: PathBuf::from("brief.md"),
@@ -476,6 +477,7 @@ mod tests {
                 workers: BTreeMap::from([(
                     worker_name,
                     WorkerRunState {
+                        task: None,
                         workspace_id: Some("worker-workspace".to_owned()),
                         pane_id: Some(worker_pane.to_owned()),
                         agent_id: Some("agent-1".to_owned()),
@@ -928,6 +930,7 @@ mod tests {
         run.state.workers.insert(
             "reviewer".to_owned(),
             WorkerRunState {
+                task: None,
                 workspace_id: Some("reviewer-workspace".to_owned()),
                 pane_id: Some("reviewer-pane".to_owned()),
                 agent_id: Some("agent-2".to_owned()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::process::ExitCode;
 
 pub mod adopt;
 pub mod agents_md;
+pub mod board;
 pub mod herdr;
 pub mod hook;
 pub mod launcher;
@@ -27,13 +28,17 @@ fn main() -> ExitCode {
 
     match command.as_str() {
         "adopt" => exit(adopt::adopt_command(&args)),
+        "board" => exit(board::board_command(&args)),
+        "open-report" => exit(board::open_report_command(&args)),
         "spawn" => exit(spawn::spawn_command(&args)),
         "status" => exit(status_kill::status_command(&args)),
         "kill" => exit(status_kill::kill_command(&args)),
         "msg" => exit(msg::msg_command(&args)),
         "on-agent-status" => exit(hook::hook_command()),
         "" | "help" | "--help" | "-h" => {
-            eprintln!("herdr-agent-team <adopt|spawn|status|kill|msg|on-agent-status>");
+            eprintln!(
+                "herdr-agent-team <adopt|board|spawn|status|kill|msg|open-report|on-agent-status>"
+            );
             ExitCode::SUCCESS
         }
         other => {

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -704,6 +704,7 @@ mod tests {
             name: worker_name.to_owned(),
             agent: agent.to_owned(),
             role: "builder".to_owned(),
+            task: None,
             worktree: false,
             branch: None,
             brief: PathBuf::from("brief.md"),
@@ -724,6 +725,7 @@ mod tests {
                 workers: BTreeMap::from([(
                     worker_name.to_owned(),
                     WorkerRunState {
+                        task: None,
                         workspace_id: Some("workspace".to_owned()),
                         pane_id: Some("worker-pane".to_owned()),
                         agent_id: Some("session".to_owned()),

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -444,6 +444,7 @@ mod tests {
                     name: "builder".to_owned(),
                     agent: "codex".to_owned(),
                     role: "build".to_owned(),
+                    task: None,
                     worktree: true,
                     branch: None,
                     brief: PathBuf::from("brief.md"),
@@ -455,6 +456,7 @@ mod tests {
             workers: BTreeMap::from([(
                 "builder".to_owned(),
                 WorkerRunState {
+                    task: None,
                     workspace_id: Some("workspace-1".to_owned()),
                     pane_id: Some("pane-1".to_owned()),
                     agent_id: None,
@@ -721,6 +723,7 @@ mod tests {
             name: "reviewer".to_owned(),
             agent: "claude".to_owned(),
             role: "review".to_owned(),
+            task: None,
             worktree: false,
             branch: None,
             brief: PathBuf::from("review.md"),
@@ -728,6 +731,7 @@ mod tests {
         two_workers.workers.insert(
             "reviewer".to_owned(),
             WorkerRunState {
+                task: None,
                 workspace_id: Some("workspace-2".to_owned()),
                 pane_id: Some("pane-2".to_owned()),
                 agent_id: None,

--- a/src/run.rs
+++ b/src/run.rs
@@ -298,6 +298,7 @@ mod tests {
         workers.insert(
             worker_name.clone(),
             WorkerRunState {
+                task: None,
                 workspace_id: Some("workspace-1".to_owned()),
                 pane_id: Some(pane_id.to_owned()),
                 agent_id: Some("agent-1".to_owned()),
@@ -320,6 +321,7 @@ mod tests {
                     name: worker_name,
                     agent: "codex".to_owned(),
                     role: "builder".to_owned(),
+                    task: None,
                     worktree: true,
                     branch: Some("ticket-06".to_owned()),
                     brief: PathBuf::from("brief.md"),
@@ -413,6 +415,8 @@ lifecycle = "running"
             Some("opaque-id")
         );
         assert_eq!(state.workers["builder"].agent_session, None);
+        assert_eq!(state.spec.workers[0].task, None);
+        assert_eq!(state.workers["builder"].task, None);
     }
 
     #[test]

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -422,6 +422,7 @@ where
             (
                 worker.name.clone(),
                 WorkerRunState {
+                    task: worker.task.clone(),
                     workspace_id: None,
                     pane_id: None,
                     agent_id: None,
@@ -1188,6 +1189,7 @@ mod tests {
             name: name.to_owned(),
             agent: agent.to_owned(),
             role: "reviewer".to_owned(),
+            task: None,
             worktree: false,
             branch: None,
             brief,

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -63,6 +63,7 @@ struct RawWorkerSpec {
     name: String,
     agent: String,
     role: String,
+    task: Option<String>,
     worktree: Option<bool>,
     branch: Option<String>,
     brief: PathBuf,
@@ -122,6 +123,7 @@ pub fn team_spec_from_agents(
                 name,
                 agent: agent.to_owned(),
                 role: SHORTHAND_ROLE.to_owned(),
+                task: None,
                 worktree: false,
                 branch: None,
             }
@@ -245,10 +247,11 @@ pub fn render_spawn_plan(spec: &TeamSpec) -> String {
     for worker in &spec.workers {
         writeln!(
             plan,
-            "  - {}: agent={} role={} worktree={} branch={} brief={}",
+            "  - {}: agent={} role={} task={} worktree={} branch={} brief={}",
             worker.name,
             worker.agent,
             worker.role,
+            worker.task.as_deref().unwrap_or("none"),
             worker.worktree,
             worker.branch.as_deref().unwrap_or("none"),
             worker.brief.display()
@@ -292,6 +295,7 @@ fn resolve_raw_spec(raw: RawTeamSpec) -> TeamSpec {
                 agent: worker.agent,
                 worktree: worker.worktree.unwrap_or_else(|| worker.role == "builder"),
                 role: worker.role,
+                task: worker.task,
                 branch: worker.branch,
                 brief: worker.brief,
             })
@@ -426,6 +430,7 @@ brief = "briefs/reviewer-1.md"
             name: name.to_owned(),
             agent: agent.to_owned(),
             role: "reviewer".to_owned(),
+            task: None,
             worktree: false,
             branch: None,
             brief: PathBuf::from(format!("briefs/{name}.md")),
@@ -459,6 +464,7 @@ brief = "briefs/reviewer-1.md"
                 name: "builder-1".to_owned(),
                 agent: "claude".to_owned(),
                 role: "builder".to_owned(),
+                task: None,
                 worktree: true,
                 branch: Some("feat/wave3-builder-1".to_owned()),
                 brief: PathBuf::from("briefs/builder-1.md"),
@@ -470,11 +476,18 @@ brief = "briefs/reviewer-1.md"
                 name: "reviewer-1".to_owned(),
                 agent: "codex".to_owned(),
                 role: "reviewer".to_owned(),
+                task: None,
                 worktree: false,
                 branch: None,
                 brief: PathBuf::from("briefs/reviewer-1.md"),
             }
         );
+    }
+
+    #[test]
+    fn parses_optional_worker_task() {
+        let spec = parse_team_spec("name = 'wave'\n[[workers]]\nname = 'builder'\nagent = 'codex'\nrole = 'builder'\ntask = 'ship control deck'\nbrief = 'brief.md'\n").expect("task is additive");
+        assert_eq!(spec.workers[0].task.as_deref(), Some("ship control deck"));
     }
 
     #[test]
@@ -607,10 +620,10 @@ brief = "briefs/reviewer-1.md"
         assert!(plan.contains("god: self"));
         assert!(plan.contains("setup: ./scripts/worktree-setup.sh"));
         assert!(plan.contains(
-            "builder-1: agent=claude role=builder worktree=true branch=feat/wave3-builder-1 brief=briefs/builder-1.md"
+            "builder-1: agent=claude role=builder task=none worktree=true branch=feat/wave3-builder-1 brief=briefs/builder-1.md"
         ));
         assert!(plan.contains(
-            "reviewer-1: agent=codex role=reviewer worktree=false branch=none brief=briefs/reviewer-1.md"
+            "reviewer-1: agent=codex role=reviewer task=none worktree=false branch=none brief=briefs/reviewer-1.md"
         ));
     }
 

--- a/src/status_kill.rs
+++ b/src/status_kill.rs
@@ -13,7 +13,8 @@ use std::time::{SystemTimeError, UNIX_EPOCH};
 use thiserror::Error;
 
 const STATUS_USAGE: &str = "usage: herdr-agent-team status <run-dir> [--json]";
-const KILL_USAGE: &str = "usage: herdr-agent-team kill <run-dir> [--remove-worktrees]";
+const KILL_USAGE: &str =
+    "usage: herdr-agent-team kill <run-dir> [--remove-worktrees] [--worker <name>]";
 
 #[derive(Debug, Error)]
 pub enum StatusKillError {
@@ -80,8 +81,17 @@ pub fn status_command(args: &[String]) -> Result<(), StatusKillError> {
 }
 
 pub fn kill_command(args: &[String]) -> Result<(), StatusKillError> {
-    let (run_dir, remove_worktrees) = parse_command_args(args, "--remove-worktrees", KILL_USAGE)?;
-    kill_run(&run_dir, remove_worktrees, &HerdrClient::from_env())
+    let (run_dir, remove_worktrees, worker) = parse_kill_args(args)?;
+    if let Some(worker) = worker {
+        kill_worker(
+            &run_dir,
+            &worker,
+            remove_worktrees,
+            &HerdrClient::from_env(),
+        )
+    } else {
+        kill_run(&run_dir, remove_worktrees, &HerdrClient::from_env())
+    }
 }
 
 pub fn status_run(
@@ -99,6 +109,65 @@ pub fn kill_run(
 ) -> Result<(), StatusKillError> {
     let backend = SystemTeardown { herdr };
     kill_run_with_backend(run_dir, remove_worktrees, &backend)
+}
+
+pub fn kill_worker(
+    run_dir: &Path,
+    worker_name: &str,
+    remove_worktrees: bool,
+    herdr: &HerdrClient,
+) -> Result<(), StatusKillError> {
+    kill_worker_with_backend(
+        run_dir,
+        worker_name,
+        remove_worktrees,
+        &SystemTeardown { herdr },
+    )
+}
+
+fn parse_kill_args(args: &[String]) -> Result<(PathBuf, bool, Option<String>), StatusKillError> {
+    let mut run_dir = None;
+    let mut remove_worktrees = false;
+    let mut worker = None;
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--remove-worktrees" if !remove_worktrees => remove_worktrees = true,
+            "--remove-worktrees" => {
+                return Err(StatusKillError::Usage(format!(
+                    "duplicate option --remove-worktrees; {KILL_USAGE}"
+                )))
+            }
+            "--worker" => {
+                index += 1;
+                let value = args.get(index).ok_or_else(|| {
+                    StatusKillError::Usage(format!("--worker requires a name; {KILL_USAGE}"))
+                })?;
+                if worker.replace(value.clone()).is_some() {
+                    return Err(StatusKillError::Usage(format!(
+                        "duplicate option --worker; {KILL_USAGE}"
+                    )));
+                }
+            }
+            value if value.starts_with('-') => {
+                return Err(StatusKillError::Usage(format!(
+                    "unknown option {value}; {KILL_USAGE}"
+                )))
+            }
+            value if run_dir.replace(PathBuf::from(value)).is_some() => {
+                return Err(StatusKillError::Usage(format!(
+                    "expected one run directory; {KILL_USAGE}"
+                )))
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    Ok((
+        run_dir.ok_or_else(|| StatusKillError::Usage(KILL_USAGE.to_owned()))?,
+        remove_worktrees,
+        worker,
+    ))
 }
 
 fn parse_command_args(
@@ -369,6 +438,82 @@ fn kill_run_with_backend(
     }
 }
 
+fn kill_worker_with_backend(
+    run_dir: &Path,
+    worker_name: &str,
+    remove_worktrees: bool,
+    backend: &impl TeardownBackend,
+) -> Result<(), StatusKillError> {
+    let mut run = load_run(run_dir)?;
+    if run.state.lifecycle == RunLifecycle::Ended {
+        return Ok(());
+    }
+    let worker = run.state.workers.get(worker_name).cloned().ok_or_else(|| {
+        StatusKillError::Usage(format!(
+            "unknown worker '{worker_name}' in {}; {KILL_USAGE}",
+            run_dir.display()
+        ))
+    })?;
+    if matches!(
+        worker.lifecycle,
+        WorkerLifecycle::Ended | WorkerLifecycle::Released | WorkerLifecycle::Failed
+    ) {
+        return Ok(());
+    }
+
+    if worker.adopted {
+        if let Some(pane_id) = worker.pane_id.as_deref() {
+            if let Err(error) = backend.pane_run(pane_id, &release_notice(&run.state.spec.name)) {
+                log_teardown_note("adopted pane", pane_id, &error);
+            }
+        }
+    } else if let Some(workspace_id) = worker.workspace_id.as_deref() {
+        if let Err(error) = backend.workspace_close(workspace_id) {
+            log_teardown_note("workspace", workspace_id, &error);
+        }
+    }
+
+    let mut dirty_paths = Vec::new();
+    if remove_worktrees && !worker.adopted {
+        if let Some(path) = worker.worktree_path.as_deref() {
+            match backend.worktree_is_dirty(path) {
+                Ok(true) => dirty_paths.push(path.to_path_buf()),
+                Ok(false) => {
+                    if let Err(error) = backend.worktree_remove(path) {
+                        log_teardown_note("worktree", &path.display().to_string(), &error);
+                    }
+                }
+                Err(error) => log_teardown_note("worktree", &path.display().to_string(), &error),
+            }
+        }
+    }
+    let terminal = if worker.adopted {
+        WorkerLifecycle::Released
+    } else {
+        WorkerLifecycle::Ended
+    };
+    run.state
+        .workers
+        .get_mut(worker_name)
+        .expect("worker was loaded above")
+        .lifecycle = terminal;
+    if run.state.workers.values().all(|state| {
+        matches!(
+            state.lifecycle,
+            WorkerLifecycle::Ended | WorkerLifecycle::Released | WorkerLifecycle::Failed
+        )
+    }) {
+        mark_ended(&mut run)?;
+    } else {
+        crate::run::save_run(&run)?;
+    }
+    if dirty_paths.is_empty() {
+        Ok(())
+    } else {
+        Err(StatusKillError::DirtyWorktrees { paths: dirty_paths })
+    }
+}
+
 fn release_adopted_workers(run: &mut RunBoard, backend: &impl TeardownBackend) {
     let pending = run
         .state
@@ -506,6 +651,7 @@ mod tests {
                 name: "builder".to_owned(),
                 agent: "codex".to_owned(),
                 role: "builder".to_owned(),
+                task: None,
                 worktree: true,
                 branch: Some("feat/builder".to_owned()),
                 brief: PathBuf::from("briefs/builder.md"),
@@ -514,12 +660,14 @@ mod tests {
                 name: "reviewer".to_owned(),
                 agent: "claude".to_owned(),
                 role: "reviewer".to_owned(),
+                task: None,
                 worktree: true,
                 branch: Some("feat/reviewer".to_owned()),
                 brief: PathBuf::from("briefs/reviewer.md"),
             },
         ];
         let runtime = |workspace: &str, pane: &str, worktree: &str| WorkerRunState {
+            task: None,
             workspace_id: Some(workspace.to_owned()),
             pane_id: Some(pane.to_owned()),
             agent_id: Some(format!("agent-{pane}")),
@@ -776,6 +924,31 @@ mod tests {
             ended.state.workers["reviewer"].lifecycle,
             WorkerLifecycle::Failed
         );
+    }
+
+    #[test]
+    fn kill_worker_leaves_other_workers_and_run_active_and_refuses_dirty_worktree() {
+        let temp = TempDir::new();
+        let state = run_state(temp.path());
+        let run = create_run(temp.path(), state).expect("create run");
+        let backend = FakeTeardown {
+            dirty: BTreeSet::from([run.state.workers["builder"].worktree_path.clone().unwrap()]),
+            ..Default::default()
+        };
+        let error = kill_worker_with_backend(&run.dir, "builder", true, &backend)
+            .expect_err("dirty worker must be preserved");
+        assert!(matches!(error, StatusKillError::DirtyWorktrees { .. }));
+        let persisted = load_run(&run.dir).expect("load run");
+        assert_eq!(persisted.state.lifecycle, RunLifecycle::Active);
+        assert_eq!(
+            persisted.state.workers["builder"].lifecycle,
+            WorkerLifecycle::Ended
+        );
+        assert_eq!(
+            persisted.state.workers["reviewer"].lifecycle,
+            WorkerLifecycle::Running
+        );
+        assert_eq!(backend.closed.into_inner(), ["workspace-builder"]);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,6 +40,8 @@ pub struct WorkerSpec {
     pub name: String,
     pub agent: String,
     pub role: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
     pub worktree: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
@@ -92,6 +94,8 @@ pub struct RunState {
 /// Live identifiers and lifecycle for one worker in a run (spec section 4).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkerRunState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary
- add the variant-D native board pane with pure rendering/action tests
- persist optional worker tasks and add per-worker kill semantics
- publish manifest, report link handler, and keybind documentation

## Verification
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test (128 passed)

Closes #7.