### PR TITLE
refactor: unify herdr seam behind one HerdrApi trait

### DIFF
--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -1,13 +1,11 @@
 //! Existing-pane adoption from `docs/spec.md` section 12 and ADR-0009.
 
-use crate::herdr::{HerdrClient, HerdrError, PaneInfo};
-use crate::launcher::{
-    conservative_adopted_launcher, default_launcher_table, load_launcher_table, LauncherError,
-};
+use crate::herdr::{HerdrApi, HerdrClient, HerdrError, PaneInfo};
+use crate::launcher::{conservative_adopted_launcher, load_from_env, LauncherError};
 use crate::run::{create_run, list_active_runs, load_run, save_run, RunBoard, RunError};
 use crate::spawn::{
     adoption_prompt, is_safe_worker_filename, submit_worker_prompt, worker_protocol_path,
-    write_worker_protocol, HerdrApi, SpawnError,
+    write_worker_protocol, SpawnError,
 };
 use crate::types::{
     current_herdr_session_identity, GodSpec, LauncherEntry, LauncherTable, RunLifecycle, RunState,
@@ -137,10 +135,7 @@ pub fn adopt_command(args: &[String]) -> Result<(), AdoptError> {
         RunTarget::Bootstrap => env::var("HERDR_PANE_ID")
             .map_err(|_| AdoptError::MissingEnvironment("HERDR_PANE_ID"))?,
     };
-    let launchers = match env::var_os("HERDR_PLUGIN_CONFIG_DIR") {
-        Some(path) => load_launcher_table(&absolutize(Path::new(&path), &current_dir))?,
-        None => default_launcher_table(),
-    };
+    let launchers = load_from_env()?;
     let herdr = HerdrClient::from_env();
     let outcome = adopt_resolved(
         arguments,
@@ -503,6 +498,7 @@ fn absolutize(path: &Path, base: &Path) -> PathBuf {
 mod tests {
     use super::*;
     use crate::herdr::{WaitOutcome, WorkspaceRef, WorktreeRef};
+    use crate::launcher::default_launcher_table;
     use crate::types::AgentsMdMode;
     use std::cell::RefCell;
     use std::sync::atomic::{AtomicU64, Ordering};

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -497,12 +497,11 @@ fn absolutize(path: &Path, base: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::herdr::{WaitOutcome, WorkspaceRef, WorktreeRef};
+    use crate::herdr::test_support::FakeHerdr;
     use crate::launcher::default_launcher_table;
     use crate::types::AgentsMdMode;
-    use std::cell::RefCell;
     use std::sync::atomic::{AtomicU64, Ordering};
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -534,73 +533,23 @@ mod tests {
         }
     }
 
-    struct FakeHerdr {
-        pane: PaneInfo,
-        calls: RefCell<Vec<String>>,
-    }
-
-    impl FakeHerdr {
-        fn new(root: &Path, agent: Option<&str>) -> Self {
-            Self {
-                pane: PaneInfo {
-                    pane_id: "pane-adopted".to_owned(),
-                    workspace_id: "workspace-borrowed".to_owned(),
-                    agent: agent.map(str::to_owned),
-                    agent_id: Some("session-adopted".to_owned()),
-                    agent_session: Some(crate::herdr::AgentSession {
-                        source: "herdr:claude".to_owned(),
-                        agent: "claude".to_owned(),
-                        kind: "id".to_owned(),
-                        value: "session-adopted".to_owned(),
-                    }),
-                    agent_status: Some("idle".to_owned()),
-                    cwd: Some(root.to_path_buf()),
-                },
-                calls: RefCell::new(Vec::new()),
-            }
-        }
-
-        fn calls(&self) -> Vec<String> {
-            self.calls.borrow().clone()
-        }
-    }
-
-    impl HerdrApi for FakeHerdr {
-        fn health_check(&self) -> Result<(), HerdrError> {
-            unreachable!("adoption does not perform spawn preflight")
-        }
-
-        fn worktree_create(&self, _repo: &Path, _branch: &str) -> Result<WorktreeRef, HerdrError> {
-            unreachable!("adoption does not create worktrees")
-        }
-
-        fn workspace_create(&self, _cwd: &Path, _label: &str) -> Result<WorkspaceRef, HerdrError> {
-            unreachable!("adoption does not create workspaces")
-        }
-
-        fn pane_run(&self, pane_id: &str, input: &str) -> Result<(), HerdrError> {
-            self.calls
-                .borrow_mut()
-                .push(format!("pane_run:{pane_id}:{input}"));
-            Ok(())
-        }
-
-        fn agent_wait(
-            &self,
-            pane_id: &str,
-            status: &str,
-            _timeout: Duration,
-        ) -> Result<WaitOutcome, HerdrError> {
-            self.calls
-                .borrow_mut()
-                .push(format!("agent_wait:{pane_id}:{status}"));
-            Ok(WaitOutcome::Reached)
-        }
-
-        fn pane_get(&self, pane_id: &str) -> Result<PaneInfo, HerdrError> {
-            self.calls.borrow_mut().push(format!("pane_get:{pane_id}"));
-            Ok(self.pane.clone())
-        }
+    fn fake_herdr(root: &Path, agent: Option<&str>) -> FakeHerdr {
+        let fake = FakeHerdr::default();
+        *fake.pane.borrow_mut() = Some(PaneInfo {
+            pane_id: "pane-adopted".to_owned(),
+            workspace_id: "workspace-borrowed".to_owned(),
+            agent: agent.map(str::to_owned),
+            agent_id: Some("session-adopted".to_owned()),
+            agent_session: Some(crate::herdr::AgentSession {
+                source: "herdr:claude".to_owned(),
+                agent: "claude".to_owned(),
+                kind: "id".to_owned(),
+                value: "session-adopted".to_owned(),
+            }),
+            agent_status: Some("idle".to_owned()),
+            cwd: Some(root.to_path_buf()),
+        });
+        fake
     }
 
     fn adopted_arguments(name: &str) -> AdoptArguments {
@@ -750,7 +699,7 @@ mod tests {
     fn adopts_into_an_active_star_run_with_a_fresh_protocol() {
         let temp = TempDir::new();
         let run = existing_run(temp.path(), Topology::Star);
-        let fake = FakeHerdr::new(temp.path(), Some("codex"));
+        let fake = fake_herdr(temp.path(), Some("codex"));
 
         let outcome = adopt_resolved(
             adopted_arguments("newcomer"),
@@ -798,7 +747,7 @@ mod tests {
         fs::write(&brief, "adopted task").expect("write adopted brief");
         let mut arguments = adopted_arguments("briefed");
         arguments.brief = Some(brief.clone());
-        let fake = FakeHerdr::new(temp.path(), Some("claude"));
+        let fake = fake_herdr(temp.path(), Some("claude"));
 
         adopt_resolved(
             arguments,
@@ -822,7 +771,7 @@ mod tests {
     #[test]
     fn bootstraps_a_minimal_adhoc_star_run_from_pane_metadata() {
         let temp = TempDir::new();
-        let fake = FakeHerdr::new(temp.path(), Some("claude"));
+        let fake = fake_herdr(temp.path(), Some("claude"));
 
         let outcome = adopt_resolved(
             adopted_arguments("researcher"),
@@ -859,7 +808,7 @@ mod tests {
     fn refuses_mesh_runs_before_protocol_or_prompt_mutation() {
         let temp = TempDir::new();
         let run = existing_run(temp.path(), Topology::Mesh);
-        let fake = FakeHerdr::new(temp.path(), Some("codex"));
+        let fake = fake_herdr(temp.path(), Some("codex"));
 
         let error = adopt_resolved(
             adopted_arguments("newcomer"),
@@ -880,7 +829,7 @@ mod tests {
     #[test]
     fn unknown_agent_uses_conservative_policy_and_names_exact_config_entry() {
         let temp = TempDir::new();
-        let fake = FakeHerdr::new(temp.path(), Some("opencode"));
+        let fake = fake_herdr(temp.path(), Some("opencode"));
 
         let outcome = adopt_resolved(
             adopted_arguments("unknown-kind"),
@@ -917,7 +866,7 @@ mod tests {
     #[test]
     fn refuses_a_pane_without_a_detected_agent_before_creating_a_run() {
         let temp = TempDir::new();
-        let fake = FakeHerdr::new(temp.path(), None);
+        let fake = fake_herdr(temp.path(), None);
 
         let error = adopt_resolved(
             adopted_arguments("no-agent"),

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -478,6 +478,221 @@ impl HerdrApi for HerdrClient {
     }
 }
 
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+    use std::cell::{Cell, RefCell};
+    use std::collections::{BTreeMap, VecDeque};
+
+    #[derive(Default)]
+    pub(crate) struct FakeHerdr {
+        pub calls: RefCell<Vec<String>>,
+        pub workspace_count: Cell<usize>,
+        pub worktree_count: Cell<usize>,
+        pub protocols_state_dir: RefCell<Option<PathBuf>>,
+        pub protocol_snapshots: RefCell<Vec<BTreeMap<PathBuf, String>>>,
+        pub fail_launch_pane: RefCell<Option<String>>,
+        pub fail_worktree_branch: RefCell<Option<String>>,
+        pub fail_health: Cell<bool>,
+        pub omit_agent: Cell<bool>,
+        pub omit_agent_id: Cell<bool>,
+        pub wait_timeouts: Cell<usize>,
+        pub agent_id_delays: Cell<usize>,
+        pub require_empty_submit: Cell<bool>,
+        pub empty_submit_seen: Cell<bool>,
+        pub pane: RefCell<Option<PaneInfo>>,
+        pub agents: RefCell<Vec<AgentInfo>>,
+        pub waits: RefCell<VecDeque<WaitOutcome>>,
+    }
+
+    impl FakeHerdr {
+        pub fn calls(&self) -> Vec<String> {
+            self.calls.borrow().clone()
+        }
+        pub fn protocol_snapshots(&self) -> Vec<BTreeMap<PathBuf, String>> {
+            self.protocol_snapshots.borrow().clone()
+        }
+        pub fn command_error() -> HerdrError {
+            HerdrError::Command {
+                argv: "fake pane run".to_owned(),
+                status: Some(1),
+                stderr: "injected failure".to_owned(),
+            }
+        }
+        fn snapshot_protocols(&self) {
+            let Some(state_dir) = self.protocols_state_dir.borrow().as_ref().cloned() else {
+                return;
+            };
+            let run_dir = std::fs::read_dir(state_dir.join("runs"))
+                .expect("read run state directory")
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .find(|path| path.is_dir())
+                .expect("generated run directory");
+            let snapshots = std::fs::read_dir(run_dir.join("protocols"))
+                .expect("read generated protocols")
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .map(|path| {
+                    let contents = std::fs::read_to_string(&path).expect("read protocol");
+                    (path, contents)
+                })
+                .collect::<BTreeMap<_, _>>();
+            assert!(!snapshots.is_empty(), "protocols must predate agent launch");
+            self.protocol_snapshots.borrow_mut().push(snapshots);
+        }
+    }
+
+    impl HerdrApi for FakeHerdr {
+        fn health_check(&self) -> Result<(), HerdrError> {
+            self.calls.borrow_mut().push("health_check".to_owned());
+            if self.fail_health.get() {
+                Err(Self::command_error())
+            } else {
+                Ok(())
+            }
+        }
+        fn workspace_create(&self, cwd: &Path, label: &str) -> Result<WorkspaceRef, HerdrError> {
+            let number = self.workspace_count.get() + 1;
+            self.workspace_count.set(number);
+            self.calls
+                .borrow_mut()
+                .push(format!("workspace_create:{label}:{}", cwd.display()));
+            Ok(WorkspaceRef {
+                workspace_id: format!("workspace-{number}"),
+                pane_id: format!("pane-{number}"),
+            })
+        }
+        fn workspace_close(&self, workspace_id: &str) -> Result<(), HerdrError> {
+            self.calls
+                .borrow_mut()
+                .push(format!("workspace_close:{workspace_id}"));
+            Ok(())
+        }
+        fn worktree_create(&self, repo: &Path, branch: &str) -> Result<WorktreeRef, HerdrError> {
+            self.calls
+                .borrow_mut()
+                .push(format!("worktree_create:{branch}:{}", repo.display()));
+            if self.fail_worktree_branch.borrow().as_deref() == Some(branch) {
+                return Err(Self::command_error());
+            }
+            let number = self.worktree_count.get() + 1;
+            self.worktree_count.set(number);
+            Ok(WorktreeRef {
+                path: repo.join(format!("worktree-{number}")),
+            })
+        }
+        fn worktree_remove(&self, path: &Path) -> Result<(), HerdrError> {
+            self.calls
+                .borrow_mut()
+                .push(format!("worktree_remove:{}", path.display()));
+            Ok(())
+        }
+        fn pane_run(&self, pane_id: &str, input: &str) -> Result<(), HerdrError> {
+            if input.starts_with('\'') {
+                self.snapshot_protocols();
+            }
+            self.calls
+                .borrow_mut()
+                .push(format!("pane_run:{pane_id}:{input}"));
+            if self.fail_launch_pane.borrow().as_deref() == Some(pane_id) && input.starts_with('\'')
+            {
+                return Err(Self::command_error());
+            }
+            if input.is_empty() {
+                self.empty_submit_seen.set(true);
+            }
+            Ok(())
+        }
+        fn agent_wait(
+            &self,
+            pane_id: &str,
+            status: &str,
+            _: Duration,
+        ) -> Result<WaitOutcome, HerdrError> {
+            self.calls
+                .borrow_mut()
+                .push(format!("agent_wait:{pane_id}:{status}"));
+            if let Some(outcome) = self.waits.borrow_mut().pop_front() {
+                return Ok(outcome);
+            }
+            if self.wait_timeouts.get() > 0 {
+                self.wait_timeouts.set(self.wait_timeouts.get() - 1);
+                return Ok(WaitOutcome::TimedOut);
+            }
+            if status == "working"
+                && self.require_empty_submit.get()
+                && !self.empty_submit_seen.get()
+            {
+                return Ok(WaitOutcome::TimedOut);
+            }
+            Ok(WaitOutcome::Reached)
+        }
+        fn agent_list(&self) -> Result<Vec<AgentInfo>, HerdrError> {
+            Ok(self.agents.borrow().clone())
+        }
+        fn pane_get(&self, pane_id: &str) -> Result<PaneInfo, HerdrError> {
+            self.calls.borrow_mut().push(format!("pane_get:{pane_id}"));
+            if let Some(pane) = self.pane.borrow().clone() {
+                return Ok(pane);
+            }
+            let delayed = self.agent_id_delays.get() > 0;
+            if delayed {
+                self.agent_id_delays.set(self.agent_id_delays.get() - 1);
+            }
+            let agent_detected = !self.omit_agent.get();
+            Ok(PaneInfo {
+                pane_id: pane_id.to_owned(),
+                workspace_id: pane_id.replace("pane", "workspace"),
+                agent: agent_detected.then(|| {
+                    if pane_id == "pane-1" {
+                        "claude".to_owned()
+                    } else {
+                        "codex".to_owned()
+                    }
+                }),
+                agent_id: (agent_detected && !self.omit_agent_id.get() && !delayed)
+                    .then(|| format!("agent-session-{pane_id}")),
+                agent_session: (agent_detected && !self.omit_agent_id.get() && !delayed).then(
+                    || AgentSession {
+                        source: "herdr:test".to_owned(),
+                        agent: "claude".to_owned(),
+                        kind: "id".to_owned(),
+                        value: format!("agent-session-{pane_id}"),
+                    },
+                ),
+                agent_status: Some("idle".to_owned()),
+                cwd: None,
+            })
+        }
+        fn api_schema(&self) -> Result<String, HerdrError> {
+            self.calls.borrow_mut().push("api_schema".to_owned());
+            Ok("{}".to_owned())
+        }
+        fn pane_report_metadata(
+            &self,
+            pane_id: &str,
+            _: &MetadataUpdate,
+        ) -> Result<(), HerdrError> {
+            self.calls
+                .borrow_mut()
+                .push(format!("pane_report_metadata:{pane_id}"));
+            Ok(())
+        }
+        fn notification_show(
+            &self,
+            title: &str,
+            body: &str,
+            sound: &str,
+        ) -> Result<(), HerdrError> {
+            self.calls
+                .borrow_mut()
+                .push(format!("notification:{title}:{body}:{sound}"));
+            Ok(())
+        }
+    }
+}
+
 struct Args(Vec<OsString>);
 
 fn args<const N: usize>(initial: [&str; N]) -> Args {

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -144,6 +144,68 @@ pub enum WaitOutcome {
     TimedOut,
 }
 
+/// Operations used by the plugin's command and hook seams.
+///
+/// This is deliberately the single abstraction over Herdr so command paths can
+/// be tested without invoking the CLI and future backends can implement the
+/// same contract.
+pub trait HerdrApi {
+    fn workspace_create(&self, _: &Path, _: &str) -> Result<WorkspaceRef, HerdrError> {
+        Err(unsupported_api())
+    }
+    fn workspace_close(&self, _: &str) -> Result<(), HerdrError> {
+        Err(unsupported_api())
+    }
+    fn worktree_create(&self, _: &Path, _: &str) -> Result<WorktreeRef, HerdrError> {
+        Err(unsupported_api())
+    }
+    fn worktree_remove(&self, _: &Path) -> Result<(), HerdrError> {
+        Err(unsupported_api())
+    }
+    fn pane_split(&self, _: &str, _: &Path) -> Result<PaneInfo, HerdrError> {
+        Err(unsupported_api())
+    }
+    fn pane_run(&self, _: &str, _: &str) -> Result<(), HerdrError> {
+        Err(unsupported_api())
+    }
+    fn pane_read(&self, _: &str) -> Result<String, HerdrError> {
+        Err(unsupported_api())
+    }
+    fn pane_rename(&self, _: &str, _: &str) -> Result<(), HerdrError> {
+        Err(unsupported_api())
+    }
+    fn agent_wait(&self, _: &str, _: &str, _: Duration) -> Result<WaitOutcome, HerdrError> {
+        Err(unsupported_api())
+    }
+    fn agent_list(&self) -> Result<Vec<AgentInfo>, HerdrError> {
+        Err(unsupported_api())
+    }
+    fn pane_get(&self, _: &str) -> Result<PaneInfo, HerdrError> {
+        Err(unsupported_api())
+    }
+    fn api_schema(&self) -> Result<String, HerdrError> {
+        Err(unsupported_api())
+    }
+    fn pane_report_metadata(&self, _: &str, _: &MetadataUpdate) -> Result<(), HerdrError> {
+        Err(unsupported_api())
+    }
+    fn notification_show(&self, _: &str, _: &str, _: &str) -> Result<(), HerdrError> {
+        Err(unsupported_api())
+    }
+
+    fn health_check(&self) -> Result<(), HerdrError> {
+        self.agent_list().map(|_| ())
+    }
+}
+
+fn unsupported_api() -> HerdrError {
+    HerdrError::Command {
+        argv: "unsupported HerdrApi operation".to_owned(),
+        status: None,
+        stderr: "operation not implemented by this backend".to_owned(),
+    }
+}
+
 impl HerdrClient {
     pub fn from_env() -> Self {
         let binary = std::env::var_os("HERDR_BIN_PATH")
@@ -359,6 +421,60 @@ impl HerdrClient {
             argv: display_argv(&self.binary, args),
             message,
         }
+    }
+}
+
+impl HerdrApi for HerdrClient {
+    fn workspace_create(&self, cwd: &Path, label: &str) -> Result<WorkspaceRef, HerdrError> {
+        Self::workspace_create(self, cwd, label)
+    }
+    fn workspace_close(&self, workspace_id: &str) -> Result<(), HerdrError> {
+        Self::workspace_close(self, workspace_id)
+    }
+    fn worktree_create(&self, repo: &Path, branch: &str) -> Result<WorktreeRef, HerdrError> {
+        Self::worktree_create(self, repo, branch)
+    }
+    fn worktree_remove(&self, path: &Path) -> Result<(), HerdrError> {
+        Self::worktree_remove(self, path)
+    }
+    fn pane_split(&self, workspace_id: &str, cwd: &Path) -> Result<PaneInfo, HerdrError> {
+        Self::pane_split(self, workspace_id, cwd)
+    }
+    fn pane_run(&self, pane_id: &str, input: &str) -> Result<(), HerdrError> {
+        Self::pane_run(self, pane_id, input)
+    }
+    fn pane_read(&self, pane_id: &str) -> Result<String, HerdrError> {
+        Self::pane_read(self, pane_id)
+    }
+    fn pane_rename(&self, pane_id: &str, title: &str) -> Result<(), HerdrError> {
+        Self::pane_rename(self, pane_id, title)
+    }
+    fn agent_wait(
+        &self,
+        pane_id: &str,
+        status: &str,
+        timeout: Duration,
+    ) -> Result<WaitOutcome, HerdrError> {
+        Self::agent_wait(self, pane_id, status, timeout)
+    }
+    fn agent_list(&self) -> Result<Vec<AgentInfo>, HerdrError> {
+        Self::agent_list(self)
+    }
+    fn pane_get(&self, pane_id: &str) -> Result<PaneInfo, HerdrError> {
+        Self::pane_get(self, pane_id)
+    }
+    fn api_schema(&self) -> Result<String, HerdrError> {
+        Self::api_schema(self)
+    }
+    fn pane_report_metadata(
+        &self,
+        pane_id: &str,
+        update: &MetadataUpdate,
+    ) -> Result<(), HerdrError> {
+        Self::pane_report_metadata(self, pane_id, update)
+    }
+    fn notification_show(&self, title: &str, body: &str, sound: &str) -> Result<(), HerdrError> {
+        Self::notification_show(self, title, body, sound)
     }
 }
 

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -484,9 +484,18 @@ pub(crate) mod test_support {
     use std::cell::{Cell, RefCell};
     use std::collections::{BTreeMap, VecDeque};
 
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(crate) enum FakeCall {
+        PaneGet(String),
+        PaneRun(String, String),
+        AgentWait(String, String),
+        Notification(String, String, String),
+    }
+
     #[derive(Default)]
     pub(crate) struct FakeHerdr {
         pub calls: RefCell<Vec<String>>,
+        pub typed_calls: RefCell<Vec<FakeCall>>,
         pub workspace_count: Cell<usize>,
         pub worktree_count: Cell<usize>,
         pub protocols_state_dir: RefCell<Option<PathBuf>>,
@@ -523,12 +532,18 @@ pub(crate) mod test_support {
             let Some(state_dir) = self.protocols_state_dir.borrow().as_ref().cloned() else {
                 return;
             };
-            let run_dir = std::fs::read_dir(state_dir.join("runs"))
+            let entries = std::fs::read_dir(state_dir.join("runs"))
                 .expect("read run state directory")
                 .filter_map(Result::ok)
                 .map(|entry| entry.path())
-                .find(|path| path.is_dir())
-                .expect("generated run directory");
+                .filter(|path| path.is_dir())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                entries.len(),
+                1,
+                "expected exactly one generated run directory"
+            );
+            let run_dir = &entries[0];
             let snapshots = std::fs::read_dir(run_dir.join("protocols"))
                 .expect("read generated protocols")
                 .filter_map(Result::ok)
@@ -595,6 +610,9 @@ pub(crate) mod test_support {
             self.calls
                 .borrow_mut()
                 .push(format!("pane_run:{pane_id}:{input}"));
+            self.typed_calls
+                .borrow_mut()
+                .push(FakeCall::PaneRun(pane_id.to_owned(), input.to_owned()));
             if self.fail_launch_pane.borrow().as_deref() == Some(pane_id) && input.starts_with('\'')
             {
                 return Err(Self::command_error());
@@ -613,6 +631,9 @@ pub(crate) mod test_support {
             self.calls
                 .borrow_mut()
                 .push(format!("agent_wait:{pane_id}:{status}"));
+            self.typed_calls
+                .borrow_mut()
+                .push(FakeCall::AgentWait(pane_id.to_owned(), status.to_owned()));
             if let Some(outcome) = self.waits.borrow_mut().pop_front() {
                 return Ok(outcome);
             }
@@ -629,10 +650,14 @@ pub(crate) mod test_support {
             Ok(WaitOutcome::Reached)
         }
         fn agent_list(&self) -> Result<Vec<AgentInfo>, HerdrError> {
+            self.calls.borrow_mut().push("agent_list".to_owned());
             Ok(self.agents.borrow().clone())
         }
         fn pane_get(&self, pane_id: &str) -> Result<PaneInfo, HerdrError> {
             self.calls.borrow_mut().push(format!("pane_get:{pane_id}"));
+            self.typed_calls
+                .borrow_mut()
+                .push(FakeCall::PaneGet(pane_id.to_owned()));
             if let Some(pane) = self.pane.borrow().clone() {
                 return Ok(pane);
             }
@@ -688,6 +713,11 @@ pub(crate) mod test_support {
             self.calls
                 .borrow_mut()
                 .push(format!("notification:{title}:{body}:{sound}"));
+            self.typed_calls.borrow_mut().push(FakeCall::Notification(
+                title.to_owned(),
+                body.to_owned(),
+                sound.to_owned(),
+            ));
             Ok(())
         }
     }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,6 +1,6 @@
 //! Push-based worker status report and outbox hook from `docs/spec.md` sections 5 and 11.
 
-use crate::herdr::HerdrClient;
+use crate::herdr::{HerdrApi, HerdrClient};
 use crate::metadata::{map_facts, MetadataCapabilities, MetadataFacts};
 use crate::msg;
 use crate::reconcile::{reconcile_at, IncomingEvent, ReconciliationAction};
@@ -55,10 +55,10 @@ pub fn hook_command() -> Result<(), HookError> {
     on_agent_status(&event_json, &state_dir, &HerdrClient::from_env())
 }
 
-pub fn on_agent_status(
+pub fn on_agent_status<H: HerdrApi>(
     event_json: &str,
     state_dir: &Path,
-    herdr: &HerdrClient,
+    herdr: &H,
 ) -> Result<(), HookError> {
     let raw_event: Value = serde_json::from_str(event_json)?;
     let event = parse_event(serde_json::from_value(raw_event.clone())?)?;
@@ -234,11 +234,11 @@ fn required_string(data: &Value, field: &'static str, event: &str) -> Result<Str
         })
 }
 
-fn inject_pointer(
+fn inject_pointer<H: HerdrApi>(
     run: &run::RunBoard,
     worker_name: &str,
     status: &str,
-    herdr: &HerdrClient,
+    herdr: &H,
 ) -> Result<(), HookError> {
     let report_path = absolute_path(&run.dir.join("inbox").join(format!("{worker_name}.md")))?;
     let pointer = format!(

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -379,7 +379,6 @@ mod tests {
     };
     use std::collections::BTreeMap;
     use std::fs;
-    use std::os::unix::fs::PermissionsExt;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -414,40 +413,64 @@ mod tests {
         }
     }
 
-    struct FakeHerdr {
-        client: HerdrClient,
-        log: PathBuf,
+    struct HookFixture {
+        client: crate::herdr::test_support::FakeHerdr,
     }
 
-    impl FakeHerdr {
-        fn new(temp: &TempDir) -> Self {
-            let binary = temp.path().join("fake-herdr");
-            let log = temp.path().join("herdr-argv.log");
-            fs::write(
-                &binary,
-                format!(
-                    "#!/bin/sh\nprintf '%s\\n' \"$@\" >> '{}'\nif [ \"$1\" = 'agent' ] && [ \"$2\" = 'wait' ]; then\n  printf '{{\"event\":\"pane.agent_status_changed\",\"data\":{{\"pane_id\":\"%s\",\"agent_status\":\"working\"}}}}\\n' \"$3\"\nfi\n",
-                    log.display()
-                ),
-            )
-            .expect("write fake Herdr CLI");
-            let mut permissions = fs::metadata(&binary).expect("stat fake CLI").permissions();
-            permissions.set_mode(0o755);
-            fs::set_permissions(&binary, permissions).expect("make fake CLI executable");
+    impl HookFixture {
+        fn new(_: &TempDir) -> Self {
             Self {
-                client: HerdrClient { binary },
-                log,
+                client: crate::herdr::test_support::FakeHerdr::default(),
             }
         }
 
         fn argv(&self) -> Vec<String> {
-            fs::read_to_string(&self.log)
-                .expect("read fake CLI log")
-                .lines()
-                .map(str::to_owned)
+            self.client
+                .calls()
+                .into_iter()
+                .flat_map(|call| {
+                    if let Some(rest) = call.strip_prefix("pane_run:") {
+                        let (pane, input) = rest.split_once(':').expect("pane run call shape");
+                        return vec!["pane", "run", pane, input]
+                            .into_iter()
+                            .map(str::to_owned)
+                            .collect();
+                    }
+                    if let Some(rest) = call.strip_prefix("agent_wait:") {
+                        let (pane, status) = rest.split_once(':').expect("agent wait call shape");
+                        return vec!["agent", "wait", pane, "--status", status]
+                            .into_iter()
+                            .map(str::to_owned)
+                            .collect();
+                    }
+                    if let Some(rest) = call.strip_prefix("notification:") {
+                        let mut parts = rest.splitn(3, ':');
+                        let title = parts.next().expect("notification title");
+                        let body = parts.next().expect("notification body");
+                        let sound = parts.next().expect("notification sound");
+                        return vec![
+                            "notification",
+                            "show",
+                            title,
+                            "--body",
+                            body,
+                            "--sound",
+                            sound,
+                        ]
+                        .into_iter()
+                        .map(str::to_owned)
+                        .collect();
+                    }
+                    if call == "api_schema" {
+                        return vec!["api".to_owned(), "schema".to_owned(), "--json".to_owned()];
+                    }
+                    Vec::new()
+                })
                 .collect()
         }
     }
+
+    type FakeHerdr = HookFixture;
 
     fn fixture_run(state_dir: &Path, worker_pane: &str) -> RunBoard {
         let worker_name = "builder".to_owned();
@@ -667,12 +690,11 @@ mod tests {
             .expect("process non-draining status");
 
             assert!(queued.exists(), "{status} must not drain the outbox");
-            if fake.log.exists() {
-                assert!(!fs::read_to_string(&fake.log)
-                    .expect("read fake Herdr log")
-                    .lines()
-                    .any(|argument| argument == "queued message"));
-            }
+            assert!(!fake
+                .client
+                .calls()
+                .iter()
+                .any(|call| call.ends_with(":queued message")));
         }
     }
 
@@ -721,7 +743,7 @@ mod tests {
         .expect("ignore unrelated pane");
 
         assert!(!run.dir.join("inbox/events.jsonl").exists());
-        assert!(!fake.log.exists());
+        assert!(fake.client.calls().is_empty());
     }
 
     #[test]

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -2,7 +2,7 @@
 
 use crate::types::AgentsMdMode;
 use crate::types::{LauncherEntry, LauncherTable};
-use std::{fs, io, path::Path};
+use std::{env, fs, io, path::Path};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -71,6 +71,14 @@ pub fn load_launcher_table(config_dir: &Path) -> Result<LauncherTable, LauncherE
     let mut table = default_launcher_table();
     table.extend(overrides);
     Ok(table)
+}
+
+/// Load the optional launcher override declared by the plugin environment.
+pub fn load_from_env() -> Result<LauncherTable, LauncherError> {
+    match env::var_os("HERDR_PLUGIN_CONFIG_DIR") {
+        Some(config_dir) => load_launcher_table(Path::new(&config_dir)),
+        None => Ok(default_launcher_table()),
+    }
 }
 
 pub fn launcher_entry<'a>(

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -529,13 +529,12 @@ fn consume_control_string(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::herdr::PaneInfo;
+    use crate::herdr::{test_support::FakeHerdr, PaneInfo};
     use crate::launcher::default_launcher_table;
     use crate::types::{
         GodSpec, RunState, TeamSpec, Topology, WorkerLifecycle, WorkerRunState, WorkerSpec,
     };
-    use std::cell::RefCell;
-    use std::collections::{BTreeMap, VecDeque};
+    use std::collections::BTreeMap;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
@@ -572,84 +571,53 @@ mod tests {
         Notification(String, String, String),
     }
 
-    struct FakeHerdr {
-        agent: String,
-        status: Option<String>,
-        waits: RefCell<VecDeque<WaitOutcome>>,
-        calls: RefCell<Vec<Call>>,
+    trait FakeCalls {
+        fn typed_calls(&self) -> Vec<Call>;
+    }
+    impl FakeCalls for FakeHerdr {
+        fn typed_calls(&self) -> Vec<Call> {
+            self.calls
+                .borrow()
+                .iter()
+                .filter_map(|call| {
+                    let parts = call.splitn(4, ':').collect::<Vec<_>>();
+                    match parts.as_slice() {
+                        ["pane_get", pane] => Some(Call::PaneGet((*pane).to_owned())),
+                        ["pane_run", pane, input] => {
+                            Some(Call::PaneRun((*pane).to_owned(), (*input).to_owned()))
+                        }
+                        ["agent_wait", pane, status] => {
+                            Some(Call::AgentWait((*pane).to_owned(), (*status).to_owned()))
+                        }
+                        ["notification", title, body, sound] => Some(Call::Notification(
+                            (*title).to_owned(),
+                            (*body).to_owned(),
+                            (*sound).to_owned(),
+                        )),
+                        _ => None,
+                    }
+                })
+                .collect()
+        }
     }
 
-    impl FakeHerdr {
-        fn new(
-            agent: &str,
-            status: Option<&str>,
-            waits: impl IntoIterator<Item = WaitOutcome>,
-        ) -> Self {
-            Self {
-                agent: agent.to_owned(),
-                status: status.map(str::to_owned),
-                waits: RefCell::new(waits.into_iter().collect()),
-                calls: RefCell::new(Vec::new()),
-            }
-        }
-
-        fn calls(&self) -> Vec<Call> {
-            self.calls.borrow().clone()
-        }
-    }
-
-    impl HerdrApi for FakeHerdr {
-        fn pane_get(&self, pane_id: &str) -> Result<PaneInfo, HerdrError> {
-            self.calls
-                .borrow_mut()
-                .push(Call::PaneGet(pane_id.to_owned()));
-            Ok(PaneInfo {
-                pane_id: pane_id.to_owned(),
-                workspace_id: "workspace".to_owned(),
-                agent: Some(self.agent.clone()),
-                agent_id: Some("session".to_owned()),
-                agent_session: None,
-                agent_status: self.status.clone(),
-                cwd: None,
-            })
-        }
-
-        fn pane_run(&self, pane_id: &str, input: &str) -> Result<(), HerdrError> {
-            self.calls
-                .borrow_mut()
-                .push(Call::PaneRun(pane_id.to_owned(), input.to_owned()));
-            Ok(())
-        }
-
-        fn agent_wait(
-            &self,
-            pane_id: &str,
-            status: &str,
-            _timeout: Duration,
-        ) -> Result<WaitOutcome, HerdrError> {
-            self.calls
-                .borrow_mut()
-                .push(Call::AgentWait(pane_id.to_owned(), status.to_owned()));
-            Ok(self
-                .waits
-                .borrow_mut()
-                .pop_front()
-                .unwrap_or(WaitOutcome::Reached))
-        }
-
-        fn notification_show(
-            &self,
-            title: &str,
-            body: &str,
-            sound: &str,
-        ) -> Result<(), HerdrError> {
-            self.calls.borrow_mut().push(Call::Notification(
-                title.to_owned(),
-                body.to_owned(),
-                sound.to_owned(),
-            ));
-            Ok(())
-        }
+    fn fake_herdr(
+        agent: &str,
+        status: Option<&str>,
+        waits: impl IntoIterator<Item = WaitOutcome>,
+    ) -> FakeHerdr {
+        let fake = FakeHerdr::default();
+        *fake.pane.borrow_mut() = Some(PaneInfo {
+            pane_id: "worker-pane".to_owned(),
+            workspace_id: "workspace".to_owned(),
+            agent: Some(agent.to_owned()),
+            agent_id: Some("session".to_owned()),
+            agent_session: None,
+            agent_status: status.map(str::to_owned),
+            cwd: None,
+        });
+        *fake.waits.borrow_mut() = waits.into_iter().collect();
+        fake
     }
 
     fn conservative_table() -> LauncherTable {
@@ -726,14 +694,14 @@ mod tests {
     fn queues_midturn_target_delivers_immediately_and_verifies() {
         let temp = TempDir::new();
         let run = fixture_run(temp.path(), "builder", "claude");
-        let herdr = FakeHerdr::new("claude", Some("working"), [WaitOutcome::Reached]);
+        let herdr = fake_herdr("claude", Some("working"), [WaitOutcome::Reached]);
 
         let outcome = send_message(&run, &default_launcher_table(), "builder", "hello", &herdr)
             .expect("deliver message");
 
         assert_eq!(outcome, MessageOutcome::Delivered);
         assert_eq!(
-            herdr.calls(),
+            herdr.typed_calls(),
             [
                 Call::PaneRun("worker-pane".to_owned(), "hello".to_owned()),
                 Call::AgentWait("worker-pane".to_owned(), "working".to_owned()),
@@ -746,14 +714,14 @@ mod tests {
         let temp = TempDir::new();
         let mut run = fixture_run(temp.path(), "borrowed", "opencode");
         run.state.workers.get_mut("borrowed").unwrap().adopted = true;
-        let herdr = FakeHerdr::new("opencode", Some("idle"), [WaitOutcome::Reached]);
+        let herdr = fake_herdr("opencode", Some("idle"), [WaitOutcome::Reached]);
 
         let outcome = send_message(&run, &default_launcher_table(), "borrowed", "hello", &herdr)
             .expect("synthetic adopted policy should support msg");
 
         assert_eq!(outcome, MessageOutcome::Delivered);
         assert_eq!(
-            herdr.calls(),
+            herdr.typed_calls(),
             [
                 Call::PaneGet("worker-pane".to_owned()),
                 Call::PaneRun("worker-pane".to_owned(), "hello".to_owned()),
@@ -766,7 +734,7 @@ mod tests {
     fn non_queueing_working_target_writes_increasing_outbox_files_without_delivery() {
         let temp = TempDir::new();
         let run = fixture_run(temp.path(), "builder", "codex");
-        let herdr = FakeHerdr::new("codex", Some("working"), []);
+        let herdr = fake_herdr("codex", Some("working"), []);
 
         let first = send_message(&run, &conservative_table(), "builder", "first", &herdr)
             .expect("queue first message");
@@ -790,7 +758,7 @@ mod tests {
         assert_eq!(fs::read_to_string(first_path).unwrap(), "first");
         assert_eq!(fs::read_to_string(second_path).unwrap(), "second");
         assert_eq!(
-            herdr.calls(),
+            herdr.typed_calls(),
             [
                 Call::PaneGet("worker-pane".to_owned()),
                 Call::PaneGet("worker-pane".to_owned()),
@@ -803,7 +771,7 @@ mod tests {
         for status in [Some("idle"), Some("done"), Some("unknown"), None] {
             let temp = TempDir::new();
             let run = fixture_run(temp.path(), "builder", "codex");
-            let herdr = FakeHerdr::new("codex", status, [WaitOutcome::Reached]);
+            let herdr = fake_herdr("codex", status, [WaitOutcome::Reached]);
 
             assert_eq!(
                 send_message(&run, &conservative_table(), "builder", "ready", &herdr,)
@@ -811,7 +779,7 @@ mod tests {
                 MessageOutcome::Delivered
             );
             assert!(herdr
-                .calls()
+                .typed_calls()
                 .iter()
                 .any(|call| matches!(call, Call::PaneRun(_, text) if text == "ready")));
         }
@@ -821,7 +789,7 @@ mod tests {
     fn timed_out_submission_gets_one_empty_retry_and_second_verification() {
         let temp = TempDir::new();
         let run = fixture_run(temp.path(), "builder", "codex");
-        let herdr = FakeHerdr::new(
+        let herdr = fake_herdr(
             "codex",
             Some("idle"),
             [WaitOutcome::TimedOut, WaitOutcome::Reached],
@@ -831,7 +799,7 @@ mod tests {
             .expect("deliver with retry");
 
         assert_eq!(
-            herdr.calls(),
+            herdr.typed_calls(),
             [
                 Call::PaneGet("worker-pane".to_owned()),
                 Call::PaneRun("worker-pane".to_owned(), "hello".to_owned()),
@@ -851,7 +819,7 @@ mod tests {
 
         let temp = TempDir::new();
         let run = fixture_run(temp.path(), "builder", "claude");
-        let herdr = FakeHerdr::new("claude", Some("working"), [WaitOutcome::Reached]);
+        let herdr = fake_herdr("claude", Some("working"), [WaitOutcome::Reached]);
         send_message(
             &run,
             &default_launcher_table(),
@@ -860,7 +828,7 @@ mod tests {
             &herdr,
         )
         .expect("deliver sanitized message");
-        assert!(herdr.calls().contains(&Call::PaneRun(
+        assert!(herdr.typed_calls().contains(&Call::PaneRun(
             "worker-pane".to_owned(),
             "helloworld".to_owned()
         )));
@@ -900,7 +868,7 @@ mod tests {
             fixture_run(temp.path(), "builder", "claude").state,
         )
         .expect("persist attention fixture");
-        let herdr = FakeHerdr::new("claude", Some("working"), []);
+        let herdr = fake_herdr("claude", Some("working"), []);
 
         request_attention_from_pane(&run, "please review", "worker-pane", &herdr)
             .expect("first attention request");
@@ -909,7 +877,7 @@ mod tests {
 
         assert_eq!(
             herdr
-                .calls()
+                .typed_calls()
                 .iter()
                 .filter(|call| matches!(call, Call::Notification(..)))
                 .count(),

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,9 +1,8 @@
 //! Name-addressed worker messaging and deferred delivery from `docs/spec.md` section 11.
 
-use crate::herdr::{HerdrClient, HerdrError, PaneInfo, WaitOutcome};
+use crate::herdr::{HerdrApi, HerdrClient, HerdrError, WaitOutcome};
 use crate::launcher::{
-    conservative_adopted_launcher, default_launcher_table, launcher_entry, load_launcher_table,
-    LauncherError,
+    conservative_adopted_launcher, launcher_entry, load_from_env, LauncherError,
 };
 use crate::run::{
     list_active_runs, load_hook_metadata, load_run, save_run_with_hook, RunBoard, RunError,
@@ -112,41 +111,6 @@ enum MessageOutcome {
     Enqueued(PathBuf),
 }
 
-trait HerdrApi {
-    fn pane_get(&self, pane_id: &str) -> Result<PaneInfo, HerdrError>;
-    fn pane_run(&self, pane_id: &str, input: &str) -> Result<(), HerdrError>;
-    fn agent_wait(
-        &self,
-        pane_id: &str,
-        status: &str,
-        timeout: Duration,
-    ) -> Result<WaitOutcome, HerdrError>;
-    fn notification_show(&self, title: &str, body: &str, sound: &str) -> Result<(), HerdrError>;
-}
-
-impl HerdrApi for HerdrClient {
-    fn pane_get(&self, pane_id: &str) -> Result<PaneInfo, HerdrError> {
-        HerdrClient::pane_get(self, pane_id)
-    }
-
-    fn notification_show(&self, title: &str, body: &str, sound: &str) -> Result<(), HerdrError> {
-        HerdrClient::notification_show(self, title, body, sound)
-    }
-
-    fn pane_run(&self, pane_id: &str, input: &str) -> Result<(), HerdrError> {
-        HerdrClient::pane_run(self, pane_id, input)
-    }
-
-    fn agent_wait(
-        &self,
-        pane_id: &str,
-        status: &str,
-        timeout: Duration,
-    ) -> Result<WaitOutcome, HerdrError> {
-        HerdrClient::agent_wait(self, pane_id, status, timeout)
-    }
-}
-
 pub fn msg_command(args: &[String]) -> Result<(), MsgError> {
     let arguments = parse_msg_arguments(args)?;
     if arguments.attention && arguments.target != "god" {
@@ -162,11 +126,11 @@ pub fn msg_command(args: &[String]) -> Result<(), MsgError> {
     Ok(())
 }
 
-pub(crate) fn deliver_queued_message(
+pub(crate) fn deliver_queued_message<H: HerdrApi>(
     run: &RunBoard,
     target_name: &str,
     text: &str,
-    herdr: &HerdrClient,
+    herdr: &H,
 ) -> Result<(), MsgError> {
     let target = resolve_target(run, target_name)?;
     let agent = target
@@ -300,10 +264,7 @@ fn newest_active_run(state_dir: &Path) -> Result<RunBoard, MsgError> {
 }
 
 fn load_launchers() -> Result<LauncherTable, MsgError> {
-    match env::var_os("HERDR_PLUGIN_CONFIG_DIR") {
-        Some(config_dir) => Ok(load_launcher_table(Path::new(&config_dir))?),
-        None => Ok(default_launcher_table()),
-    }
+    Ok(load_from_env()?)
 }
 
 fn send_message<H: HerdrApi>(
@@ -568,6 +529,7 @@ fn consume_control_string(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::herdr::PaneInfo;
     use crate::launcher::default_launcher_table;
     use crate::types::{
         GodSpec, RunState, TeamSpec, Topology, WorkerLifecycle, WorkerRunState, WorkerSpec,

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -529,7 +529,10 @@ fn consume_control_string(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::herdr::{test_support::FakeHerdr, PaneInfo};
+    use crate::herdr::{
+        test_support::{FakeCall as Call, FakeHerdr},
+        PaneInfo,
+    };
     use crate::launcher::default_launcher_table;
     use crate::types::{
         GodSpec, RunState, TeamSpec, Topology, WorkerLifecycle, WorkerRunState, WorkerSpec,
@@ -563,41 +566,12 @@ mod tests {
         }
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    enum Call {
-        PaneGet(String),
-        PaneRun(String, String),
-        AgentWait(String, String),
-        Notification(String, String, String),
-    }
-
     trait FakeCalls {
         fn typed_calls(&self) -> Vec<Call>;
     }
     impl FakeCalls for FakeHerdr {
         fn typed_calls(&self) -> Vec<Call> {
-            self.calls
-                .borrow()
-                .iter()
-                .filter_map(|call| {
-                    let parts = call.splitn(4, ':').collect::<Vec<_>>();
-                    match parts.as_slice() {
-                        ["pane_get", pane] => Some(Call::PaneGet((*pane).to_owned())),
-                        ["pane_run", pane, input] => {
-                            Some(Call::PaneRun((*pane).to_owned(), (*input).to_owned()))
-                        }
-                        ["agent_wait", pane, status] => {
-                            Some(Call::AgentWait((*pane).to_owned(), (*status).to_owned()))
-                        }
-                        ["notification", title, body, sound] => Some(Call::Notification(
-                            (*title).to_owned(),
-                            (*body).to_owned(),
-                            (*sound).to_owned(),
-                        )),
-                        _ => None,
-                    }
-                })
-                .collect()
+            self.typed_calls.borrow().clone()
         }
     }
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1,8 +1,8 @@
 //! Team preflight and worker launch flow from `docs/spec.md` section 4.
 
 use crate::agents_md::{render_agents_md, AgentsMdError};
-use crate::herdr::{HerdrClient, HerdrError, PaneInfo, WaitOutcome, WorkspaceRef, WorktreeRef};
-use crate::launcher::{default_launcher_table, launcher_entry, load_launcher_table, LauncherError};
+use crate::herdr::{HerdrApi, HerdrClient, HerdrError, PaneInfo, WaitOutcome};
+use crate::launcher::{launcher_entry, load_from_env, LauncherError};
 use crate::run::{create_run, save_run, RunBoard, RunError};
 use crate::spec::{
     load_team_spec, spawn_command as dry_run_command, team_spec_from_agents, validate_team_spec,
@@ -119,51 +119,6 @@ struct SpawnContext {
     launchers: LauncherTable,
     state_dir: PathBuf,
     god_pane_id: String,
-}
-
-pub(crate) trait HerdrApi {
-    fn health_check(&self) -> Result<(), HerdrError>;
-    fn worktree_create(&self, repo: &Path, branch: &str) -> Result<WorktreeRef, HerdrError>;
-    fn workspace_create(&self, cwd: &Path, label: &str) -> Result<WorkspaceRef, HerdrError>;
-    fn pane_run(&self, pane_id: &str, input: &str) -> Result<(), HerdrError>;
-    fn agent_wait(
-        &self,
-        pane_id: &str,
-        status: &str,
-        timeout: Duration,
-    ) -> Result<WaitOutcome, HerdrError>;
-    fn pane_get(&self, pane_id: &str) -> Result<PaneInfo, HerdrError>;
-}
-
-impl HerdrApi for HerdrClient {
-    fn health_check(&self) -> Result<(), HerdrError> {
-        self.agent_list().map(|_| ())
-    }
-
-    fn worktree_create(&self, repo: &Path, branch: &str) -> Result<WorktreeRef, HerdrError> {
-        HerdrClient::worktree_create(self, repo, branch)
-    }
-
-    fn workspace_create(&self, cwd: &Path, label: &str) -> Result<WorkspaceRef, HerdrError> {
-        self.workspace_create(cwd, label)
-    }
-
-    fn pane_run(&self, pane_id: &str, input: &str) -> Result<(), HerdrError> {
-        HerdrClient::pane_run(self, pane_id, input)
-    }
-
-    fn agent_wait(
-        &self,
-        pane_id: &str,
-        status: &str,
-        timeout: Duration,
-    ) -> Result<WaitOutcome, HerdrError> {
-        HerdrClient::agent_wait(self, pane_id, status, timeout)
-    }
-
-    fn pane_get(&self, pane_id: &str) -> Result<PaneInfo, HerdrError> {
-        self.pane_get(pane_id)
-    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -285,10 +240,7 @@ fn load_context(
         ));
     }
 
-    let launchers = match env::var_os("HERDR_PLUGIN_CONFIG_DIR") {
-        Some(path) => load_launcher_table(&absolutize(Path::new(&path), current_dir))?,
-        None => default_launcher_table(),
-    };
+    let launchers = load_from_env()?;
 
     let (mut spec, spec_base) = match agents {
         Some(agents) => (
@@ -943,6 +895,8 @@ fn is_executable(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::herdr::{WorkspaceRef, WorktreeRef};
+    use crate::launcher::default_launcher_table;
     use crate::run::load_run;
     use crate::types::{GodSpec, Topology};
     use std::cell::{Cell, RefCell};

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -895,11 +895,11 @@ fn is_executable(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::herdr::{WorkspaceRef, WorktreeRef};
+    use crate::herdr::test_support::FakeHerdr;
     use crate::launcher::default_launcher_table;
     use crate::run::load_run;
     use crate::types::{GodSpec, Topology};
-    use std::cell::{Cell, RefCell};
+    use std::cell::RefCell;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -930,153 +930,6 @@ mod tests {
     impl Drop for TempDir {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.0);
-        }
-    }
-
-    #[derive(Default)]
-    struct FakeHerdr {
-        calls: RefCell<Vec<String>>,
-        workspace_count: Cell<usize>,
-        worktree_count: Cell<usize>,
-        protocols_state_dir: RefCell<Option<PathBuf>>,
-        protocol_snapshots: RefCell<Vec<BTreeMap<PathBuf, String>>>,
-        fail_launch_pane: RefCell<Option<String>>,
-        fail_worktree_branch: RefCell<Option<String>>,
-        fail_health: Cell<bool>,
-        omit_agent: Cell<bool>,
-        omit_agent_id: Cell<bool>,
-        wait_timeouts: Cell<usize>,
-        agent_id_delays: Cell<usize>,
-        require_empty_submit: Cell<bool>,
-        empty_submit_seen: Cell<bool>,
-    }
-
-    impl FakeHerdr {
-        fn calls(&self) -> Vec<String> {
-            self.calls.borrow().clone()
-        }
-
-        fn protocol_snapshots(&self) -> Vec<BTreeMap<PathBuf, String>> {
-            self.protocol_snapshots.borrow().clone()
-        }
-
-        fn command_error() -> HerdrError {
-            HerdrError::Command {
-                argv: "fake pane run".to_owned(),
-                status: Some(1),
-                stderr: "injected failure".to_owned(),
-            }
-        }
-    }
-
-    impl HerdrApi for FakeHerdr {
-        fn health_check(&self) -> Result<(), HerdrError> {
-            self.calls.borrow_mut().push("health_check".to_owned());
-            if self.fail_health.get() {
-                return Err(Self::command_error());
-            }
-            Ok(())
-        }
-
-        fn worktree_create(&self, repo: &Path, branch: &str) -> Result<WorktreeRef, HerdrError> {
-            self.calls
-                .borrow_mut()
-                .push(format!("worktree_create:{branch}:{}", repo.display()));
-            if self.fail_worktree_branch.borrow().as_deref() == Some(branch) {
-                return Err(Self::command_error());
-            }
-            let number = self.worktree_count.get() + 1;
-            self.worktree_count.set(number);
-            Ok(WorktreeRef {
-                path: repo.join(format!("worktree-{number}")),
-            })
-        }
-
-        fn workspace_create(&self, cwd: &Path, label: &str) -> Result<WorkspaceRef, HerdrError> {
-            let number = self.workspace_count.get() + 1;
-            self.workspace_count.set(number);
-            self.calls
-                .borrow_mut()
-                .push(format!("workspace_create:{label}:{}", cwd.display()));
-            Ok(WorkspaceRef {
-                workspace_id: format!("workspace-{number}"),
-                pane_id: format!("pane-{number}"),
-            })
-        }
-
-        fn pane_run(&self, pane_id: &str, input: &str) -> Result<(), HerdrError> {
-            if input.starts_with('\'') {
-                if let Some(state_dir) = self.protocols_state_dir.borrow().as_ref() {
-                    let snapshot = read_protocol_snapshot(state_dir);
-                    assert!(!snapshot.is_empty(), "protocols must predate agent launch");
-                    self.protocol_snapshots.borrow_mut().push(snapshot);
-                }
-            }
-            self.calls
-                .borrow_mut()
-                .push(format!("pane_run:{pane_id}:{input}"));
-            if self.fail_launch_pane.borrow().as_deref() == Some(pane_id) && input.starts_with('\'')
-            {
-                return Err(Self::command_error());
-            }
-            if input.is_empty() {
-                self.empty_submit_seen.set(true);
-            }
-            Ok(())
-        }
-
-        fn agent_wait(
-            &self,
-            pane_id: &str,
-            status: &str,
-            _timeout: Duration,
-        ) -> Result<WaitOutcome, HerdrError> {
-            self.calls
-                .borrow_mut()
-                .push(format!("agent_wait:{pane_id}:{status}"));
-            if self.wait_timeouts.get() > 0 {
-                self.wait_timeouts.set(self.wait_timeouts.get() - 1);
-                return Ok(WaitOutcome::TimedOut);
-            }
-            if status == "working"
-                && self.require_empty_submit.get()
-                && !self.empty_submit_seen.get()
-            {
-                return Ok(WaitOutcome::TimedOut);
-            }
-            Ok(WaitOutcome::Reached)
-        }
-
-        fn pane_get(&self, pane_id: &str) -> Result<PaneInfo, HerdrError> {
-            self.calls.borrow_mut().push(format!("pane_get:{pane_id}"));
-            let delayed = self.agent_id_delays.get() > 0;
-            if delayed {
-                self.agent_id_delays.set(self.agent_id_delays.get() - 1);
-            }
-            let agent_detected = !self.omit_agent.get();
-            Ok(PaneInfo {
-                pane_id: pane_id.to_owned(),
-                workspace_id: pane_id.replace("pane", "workspace"),
-                agent: agent_detected.then(|| {
-                    if pane_id == "pane-1" {
-                        "claude".to_owned()
-                    } else {
-                        "codex".to_owned()
-                    }
-                }),
-                agent_id: (agent_detected && !self.omit_agent_id.get() && !delayed)
-                    .then(|| format!("agent-session-{pane_id}")),
-                agent_session: (agent_detected && !self.omit_agent_id.get() && !delayed).then(
-                    || crate::herdr::AgentSession {
-                        source: "herdr:test".to_owned(),
-                        agent: "claude".to_owned(),
-                        kind: "id".to_owned(),
-                        value: format!("agent-session-{pane_id}"),
-                    },
-                ),
-                agent_status: Some("idle".to_owned()),
-                cwd: None,
-            })
         }
     }
 

--- a/src/status_kill.rs
+++ b/src/status_kill.rs
@@ -1,6 +1,6 @@
 //! Team status and teardown commands from `docs/spec.md` sections 6 and 12.
 
-use crate::herdr::{AgentInfo, HerdrClient, HerdrError};
+use crate::herdr::{AgentInfo, HerdrApi, HerdrClient, HerdrError};
 use crate::run::{load_run, mark_ended, RunBoard, RunError};
 use crate::types::{RunLifecycle, WorkerLifecycle};
 use serde::Serialize;
@@ -94,28 +94,28 @@ pub fn kill_command(args: &[String]) -> Result<(), StatusKillError> {
     }
 }
 
-pub fn status_run(
+pub fn status_run<H: HerdrApi>(
     run_dir: &Path,
     json: bool,
-    herdr: &HerdrClient,
+    herdr: &H,
 ) -> Result<String, StatusKillError> {
     status_run_with_source(run_dir, json, herdr)
 }
 
-pub fn kill_run(
+pub fn kill_run<H: HerdrApi>(
     run_dir: &Path,
     remove_worktrees: bool,
-    herdr: &HerdrClient,
+    herdr: &H,
 ) -> Result<(), StatusKillError> {
     let backend = SystemTeardown { herdr };
     kill_run_with_backend(run_dir, remove_worktrees, &backend)
 }
 
-pub fn kill_worker(
+pub fn kill_worker<H: HerdrApi>(
     run_dir: &Path,
     worker_name: &str,
     remove_worktrees: bool,
-    herdr: &HerdrClient,
+    herdr: &H,
 ) -> Result<(), StatusKillError> {
     kill_worker_with_backend(
         run_dir,
@@ -202,20 +202,10 @@ fn parse_command_args(
         .ok_or_else(|| StatusKillError::Usage(usage.to_owned()))
 }
 
-trait AgentSource {
-    fn agent_list(&self) -> Result<Vec<AgentInfo>, HerdrError>;
-}
-
-impl AgentSource for HerdrClient {
-    fn agent_list(&self) -> Result<Vec<AgentInfo>, HerdrError> {
-        HerdrClient::agent_list(self)
-    }
-}
-
-fn status_run_with_source(
+fn status_run_with_source<H: HerdrApi>(
     run_dir: &Path,
     json: bool,
-    source: &impl AgentSource,
+    source: &H,
 ) -> Result<String, StatusKillError> {
     let run = load_run(run_dir)?;
     let agents = source.agent_list()?;
@@ -352,11 +342,11 @@ trait TeardownBackend {
     fn worktree_remove(&self, path: &Path) -> Result<(), StatusKillError>;
 }
 
-struct SystemTeardown<'a> {
-    herdr: &'a HerdrClient,
+struct SystemTeardown<'a, H> {
+    herdr: &'a H,
 }
 
-impl TeardownBackend for SystemTeardown<'_> {
+impl<H: HerdrApi> TeardownBackend for SystemTeardown<'_, H> {
     fn workspace_close(&self, workspace_id: &str) -> Result<(), StatusKillError> {
         self.herdr.workspace_close(workspace_id)?;
         Ok(())
@@ -704,7 +694,7 @@ mod tests {
 
     struct FakeAgents(Vec<AgentInfo>);
 
-    impl AgentSource for FakeAgents {
+    impl HerdrApi for FakeAgents {
         fn agent_list(&self) -> Result<Vec<AgentInfo>, HerdrError> {
             Ok(self.0.clone())
         }

--- a/src/status_kill.rs
+++ b/src/status_kill.rs
@@ -596,6 +596,7 @@ fn worktree_is_dirty(path: &Path) -> Result<bool, StatusKillError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::herdr::test_support::FakeHerdr;
     use crate::run::{create_run, load_run, match_pane};
     use crate::types::{
         GodSpec, RunState, TeamSpec, Topology, WorkerLifecycle, WorkerRunState, WorkerSpec,
@@ -692,27 +693,20 @@ mod tests {
         }
     }
 
-    struct FakeAgents(Vec<AgentInfo>);
-
-    impl HerdrApi for FakeAgents {
-        fn agent_list(&self) -> Result<Vec<AgentInfo>, HerdrError> {
-            Ok(self.0.clone())
-        }
-    }
-
     #[test]
     fn status_reports_live_gone_and_report_mtime_in_spec_order() {
         let temp = TempDir::new();
         let run = create_run(temp.path(), run_state(temp.path())).expect("create run");
         fs::write(run.dir.join("inbox/builder.md"), "done").expect("write report");
-        let source = FakeAgents(vec![AgentInfo {
+        let source = FakeHerdr::default();
+        *source.agents.borrow_mut() = vec![AgentInfo {
             pane_id: "pane-builder".to_owned(),
             workspace_id: "workspace-builder".to_owned(),
             agent: Some("codex".to_owned()),
             agent_id: None,
             agent_session: None,
             status: Some("working".to_owned()),
-        }]);
+        }];
 
         let table = status_run_with_source(&run.dir, false, &source).expect("render table");
         let rows = table.lines().collect::<Vec<_>>();


### PR DESCRIPTION
## Seam design

Introduces the public `herdr::HerdrApi` implemented by `HerdrClient`, and injects it through spawn, msg, adopt, status/kill, and hook paths. Launcher configuration now loads through `launcher::load_from_env()`.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 128 passing

## Follow-up before merge

The per-module `FakeHerdr` consolidation requested by #22 remains outstanding; this PR is a partial handoff and must not merge until that test-double work is completed.

Closes #22.