### PR TITLE
feat: spawn resume + parallel worker launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -56,6 +56,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +76,7 @@ name = "herdr-agent-team"
 version = "0.6.0"
 dependencies = [
  "crossterm",
+ "fs4",
  "serde",
  "serde_json",
  "thiserror",
@@ -99,6 +110,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -192,8 +209,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/caioniehues/herdr-agent-team"
 
 [dependencies]
 crossterm = "0.28"
+fs4 = { version = "1.1", features = ["sync"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -122,7 +122,7 @@ Given a spec (file or shorthand):
      reach the god.
    - **mesh**: all star content plus the peer table and message envelope.
    Repository-authored `AGENTS.md` files remain untouched and in effect.
-5. Per worker:
+5. Launch all workers concurrently. Each worker independently:
    a. Launch agent CLI via `herdr pane run` in that workspace. **cwd is set at
       pane creation, never via a `cd` in the prompt.**
    b. Inject one launch-prompt line containing the absolute brief path and that
@@ -130,7 +130,21 @@ Given a spec (file or shorthand):
       When `submit_verify = true`, verify with
       `herdr agent wait --status working`; on timeout, retry once with an empty
       `pane run` and verify again.
-6. Record every worker's herdr agent id/name in `run.toml`.
+   c. Persist the worker as `running` with launch checkpoint `brief_submitted`.
+      Run-board mutation and the existing atomic temp-file rename are serialized,
+      so concurrent checkpoints cannot overwrite one another.
+6. After brief submission, poll lazily for each optional Herdr `agent_session`.
+   Persist it when available; missing identity does not delay this or another
+   worker's brief and does not fail an otherwise running worker.
+
+`team spawn --resume <run-dir>` resumes an interrupted active run. Workers with
+`lifecycle = running` are untouched. For each `pending` worker, resume reuses a
+live recorded pane and existing worktree, creates any absent resource, and
+recreates a workspace when the recorded pane is gone. Existing immutable worker
+protocols are reused; missing protocols are generated before launch. Resume then
+runs the same concurrent launch + brief flow and advances checkpoints from
+`pending` to `resources_ready` to `brief_submitted`. A run with no pending
+workers is an idempotent no-op with a clear message.
 
 ## 5. Report flow (push, not poll)
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -131,20 +131,24 @@ Given a spec (file or shorthand):
       `herdr agent wait --status working`; on timeout, retry once with an empty
       `pane run` and verify again.
    c. Persist the worker as `running` with launch checkpoint `brief_submitted`.
-      Run-board mutation and the existing atomic temp-file rename are serialized,
-      so concurrent checkpoints cannot overwrite one another.
+      Spawn checkpoint updates and hook reconciliation take a run-scoped
+      advisory file lock around a fresh load, narrow mutation/reconciliation,
+      and the existing atomic temp-file rename. Spawn threads and separate hook
+      processes therefore cannot overwrite one another with stale snapshots.
 6. After brief submission, poll lazily for each optional Herdr `agent_session`.
    Persist it when available; missing identity does not delay this or another
    worker's brief and does not fail an otherwise running worker.
 
-`team spawn --resume <run-dir>` resumes an interrupted active run. Workers with
-`lifecycle = running` are untouched. For each `pending` worker, resume reuses a
-live recorded pane and existing worktree, creates any absent resource, and
-recreates a workspace when the recorded pane is gone. Existing immutable worker
-protocols are reused; missing protocols are generated before launch. Resume then
-runs the same concurrent launch + brief flow and advances checkpoints from
-`pending` to `resources_ready` to `brief_submitted`. A run with no pending
-workers is an idempotent no-op with a clear message.
+`team spawn --resume <run-dir>` resumes an interrupted active run. Running and
+adopted workers are untouched. For each spawn-owned `pending` worker, resume
+reuses a live recorded pane and existing worktree, creates any absent resource,
+and recreates a workspace when the recorded pane is gone. If the live pane
+already reports an agent, resume skips the launcher command and continues with
+brief submission; otherwise it launches the agent CLI first. Existing immutable
+worker protocols are reused; missing protocols are generated before launch.
+Resume advances checkpoints from `pending` to `resources_ready` to
+`brief_submitted`. A run with no spawn-owned pending workers is an idempotent
+no-op with a clear message.
 
 ## 5. Report flow (push, not poll)
 

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -459,6 +459,7 @@ fn insert_adopted_worker(state: &mut RunState, worker: &WorkerSpec, pane: &PaneI
             agent_session: pane.agent_session.clone(),
             worktree_path: None,
             adopted: true,
+            launch_checkpoint: crate::types::WorkerLaunchCheckpoint::Pending,
             lifecycle: WorkerLifecycle::Pending,
         },
     );
@@ -596,6 +597,7 @@ mod tests {
                         agent_session: None,
                         worktree_path: None,
                         adopted: false,
+                        launch_checkpoint: Default::default(),
                         lifecycle: WorkerLifecycle::Running,
                     },
                 )]),

--- a/src/agents_md.rs
+++ b/src/agents_md.rs
@@ -228,6 +228,7 @@ mod tests {
             agent_session: None,
             worktree_path: worktree_path.map(PathBuf::from),
             adopted: false,
+            launch_checkpoint: Default::default(),
             lifecycle: WorkerLifecycle::Running,
         };
         let run = RunState {

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -481,8 +481,34 @@ impl HerdrApi for HerdrClient {
 #[cfg(test)]
 pub(crate) mod test_support {
     use super::*;
-    use std::cell::{Cell, RefCell};
-    use std::collections::{BTreeMap, VecDeque};
+    use std::collections::{BTreeMap, BTreeSet, VecDeque};
+    use std::sync::{Arc, Barrier, Mutex, MutexGuard};
+
+    #[derive(Default)]
+    pub(crate) struct SyncCell<T>(Mutex<T>);
+
+    impl<T: Copy> SyncCell<T> {
+        pub fn get(&self) -> T {
+            *self.0.lock().expect("fake cell lock")
+        }
+
+        pub fn set(&self, value: T) {
+            *self.0.lock().expect("fake cell lock") = value;
+        }
+    }
+
+    #[derive(Default)]
+    pub(crate) struct SyncRefCell<T>(Mutex<T>);
+
+    impl<T> SyncRefCell<T> {
+        pub fn borrow(&self) -> MutexGuard<'_, T> {
+            self.0.lock().expect("fake refcell lock")
+        }
+
+        pub fn borrow_mut(&self) -> MutexGuard<'_, T> {
+            self.0.lock().expect("fake refcell lock")
+        }
+    }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub(crate) enum FakeCall {
@@ -494,24 +520,26 @@ pub(crate) mod test_support {
 
     #[derive(Default)]
     pub(crate) struct FakeHerdr {
-        pub calls: RefCell<Vec<String>>,
-        pub typed_calls: RefCell<Vec<FakeCall>>,
-        pub workspace_count: Cell<usize>,
-        pub worktree_count: Cell<usize>,
-        pub protocols_state_dir: RefCell<Option<PathBuf>>,
-        pub protocol_snapshots: RefCell<Vec<BTreeMap<PathBuf, String>>>,
-        pub fail_launch_pane: RefCell<Option<String>>,
-        pub fail_worktree_branch: RefCell<Option<String>>,
-        pub fail_health: Cell<bool>,
-        pub omit_agent: Cell<bool>,
-        pub omit_agent_id: Cell<bool>,
-        pub wait_timeouts: Cell<usize>,
-        pub agent_id_delays: Cell<usize>,
-        pub require_empty_submit: Cell<bool>,
-        pub empty_submit_seen: Cell<bool>,
-        pub pane: RefCell<Option<PaneInfo>>,
-        pub agents: RefCell<Vec<AgentInfo>>,
-        pub waits: RefCell<VecDeque<WaitOutcome>>,
+        pub calls: SyncRefCell<Vec<String>>,
+        pub typed_calls: SyncRefCell<Vec<FakeCall>>,
+        pub workspace_count: SyncCell<usize>,
+        pub worktree_count: SyncCell<usize>,
+        pub protocols_state_dir: SyncRefCell<Option<PathBuf>>,
+        pub protocol_snapshots: SyncRefCell<Vec<BTreeMap<PathBuf, String>>>,
+        pub fail_launch_pane: SyncRefCell<Option<String>>,
+        pub fail_worktree_branch: SyncRefCell<Option<String>>,
+        pub missing_panes: SyncRefCell<BTreeSet<String>>,
+        pub launch_barrier: SyncRefCell<Option<Arc<Barrier>>>,
+        pub fail_health: SyncCell<bool>,
+        pub omit_agent: SyncCell<bool>,
+        pub omit_agent_id: SyncCell<bool>,
+        pub wait_timeouts: SyncCell<usize>,
+        pub agent_id_delays: SyncCell<usize>,
+        pub require_empty_submit: SyncCell<bool>,
+        pub empty_submit_seen: SyncCell<bool>,
+        pub pane: SyncRefCell<Option<PaneInfo>>,
+        pub agents: SyncRefCell<Vec<AgentInfo>>,
+        pub waits: SyncRefCell<VecDeque<WaitOutcome>>,
     }
 
     impl FakeHerdr {
@@ -606,6 +634,10 @@ pub(crate) mod test_support {
         fn pane_run(&self, pane_id: &str, input: &str) -> Result<(), HerdrError> {
             if input.starts_with('\'') {
                 self.snapshot_protocols();
+                let barrier = self.launch_barrier.borrow().clone();
+                if let Some(barrier) = barrier {
+                    barrier.wait();
+                }
             }
             self.calls
                 .borrow_mut()
@@ -658,6 +690,9 @@ pub(crate) mod test_support {
             self.typed_calls
                 .borrow_mut()
                 .push(FakeCall::PaneGet(pane_id.to_owned()));
+            if self.missing_panes.borrow().contains(pane_id) {
+                return Err(Self::command_error());
+            }
             if let Some(pane) = self.pane.borrow().clone() {
                 return Ok(pane);
             }

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -482,7 +482,30 @@ impl HerdrApi for HerdrClient {
 pub(crate) mod test_support {
     use super::*;
     use std::collections::{BTreeMap, BTreeSet, VecDeque};
-    use std::sync::{Arc, Barrier, Mutex, MutexGuard};
+    use std::sync::{Arc, Barrier, Condvar, Mutex, MutexGuard};
+
+    pub(crate) struct BriefOrder {
+        remaining: Mutex<VecDeque<String>>,
+        changed: Condvar,
+    }
+
+    impl BriefOrder {
+        pub fn new(panes: impl IntoIterator<Item = impl Into<String>>) -> Self {
+            Self {
+                remaining: Mutex::new(panes.into_iter().map(Into::into).collect()),
+                changed: Condvar::new(),
+            }
+        }
+
+        fn wait_turn(&self, pane_id: &str) {
+            let mut remaining = self.remaining.lock().expect("brief order lock");
+            while remaining.front().map(String::as_str) != Some(pane_id) {
+                remaining = self.changed.wait(remaining).expect("brief order wait");
+            }
+            remaining.pop_front();
+            self.changed.notify_all();
+        }
+    }
 
     #[derive(Default)]
     pub(crate) struct SyncCell<T>(Mutex<T>);
@@ -530,6 +553,7 @@ pub(crate) mod test_support {
         pub fail_worktree_branch: SyncRefCell<Option<String>>,
         pub missing_panes: SyncRefCell<BTreeSet<String>>,
         pub launch_barrier: SyncRefCell<Option<Arc<Barrier>>>,
+        pub brief_order: SyncRefCell<Option<Arc<BriefOrder>>>,
         pub fail_health: SyncCell<bool>,
         pub omit_agent: SyncCell<bool>,
         pub omit_agent_id: SyncCell<bool>,
@@ -637,6 +661,12 @@ pub(crate) mod test_support {
                 let barrier = self.launch_barrier.borrow().clone();
                 if let Some(barrier) = barrier {
                     barrier.wait();
+                }
+            }
+            if input.starts_with("Read your brief") {
+                let order = self.brief_order.borrow().clone();
+                if let Some(order) = order {
+                    order.wait_turn(pane_id);
                 }
             }
             self.calls

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -507,6 +507,7 @@ mod tests {
                         agent_session: None,
                         worktree_path: None,
                         adopted: false,
+                        launch_checkpoint: Default::default(),
                         lifecycle: WorkerLifecycle::Running,
                     },
                 )]),
@@ -959,6 +960,7 @@ mod tests {
                 agent_session: None,
                 worktree_path: None,
                 adopted: false,
+                launch_checkpoint: Default::default(),
                 lifecycle: WorkerLifecycle::Running,
             },
         );

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -63,8 +63,7 @@ pub fn on_agent_status<H: HerdrApi>(
     let raw_event: Value = serde_json::from_str(event_json)?;
     let event = parse_event(serde_json::from_value(raw_event.clone())?)?;
 
-    for mut run in run::list_active_runs(state_dir)? {
-        let metadata = run::load_hook_metadata(&run.dir)?;
+    for listed_run in run::list_active_runs(state_dir)? {
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_err(run::RunError::from)?
@@ -74,27 +73,30 @@ pub fn on_agent_status<H: HerdrApi>(
             .ok()
             .and_then(|value| value.parse().ok())
             .unwrap_or(300_000);
-        let mut reconciliation = reconcile_at(
-            &event,
-            run.state.clone(),
-            metadata,
-            now_ms,
-            blocked_threshold_ms,
-        );
+        let (run, reconciliation) =
+            run::update_run_with_hook(&listed_run.dir, |run, metadata| -> Result<_, HookError> {
+                let mut reconciliation = reconcile_at(
+                    &event,
+                    run.state.clone(),
+                    metadata.clone(),
+                    now_ms,
+                    blocked_threshold_ms,
+                );
+                if reconciliation.metadata.metadata_capabilities.is_none()
+                    && reconciliation.actions.iter().any(|action| {
+                        matches!(action, ReconciliationAction::PublishMetadata { .. })
+                    })
+                {
+                    reconciliation.metadata.metadata_capabilities =
+                        Some(MetadataCapabilities::from_schema(&herdr.api_schema()?));
+                }
+                run.state = reconciliation.state.clone();
+                *metadata = reconciliation.metadata.clone();
+                Ok(reconciliation)
+            })?;
         if reconciliation.actions.is_empty() {
             continue;
         }
-        if reconciliation.metadata.metadata_capabilities.is_none()
-            && reconciliation
-                .actions
-                .iter()
-                .any(|action| matches!(action, ReconciliationAction::PublishMetadata { .. }))
-        {
-            reconciliation.metadata.metadata_capabilities =
-                Some(MetadataCapabilities::from_schema(&herdr.api_schema()?));
-        }
-        run.state = reconciliation.state;
-        run::save_run_with_hook(&run, &reconciliation.metadata)?;
         run::append_event(&run.dir, &raw_event)?;
 
         for action in reconciliation.actions {

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -636,6 +636,7 @@ mod tests {
                         agent_session: None,
                         worktree_path: None,
                         adopted: false,
+                        launch_checkpoint: Default::default(),
                         lifecycle: WorkerLifecycle::Running,
                     },
                 )]),

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -463,6 +463,7 @@ mod tests {
                     agent_session: None,
                     worktree_path: Some(PathBuf::from("/tmp/worktree")),
                     adopted: false,
+                    launch_checkpoint: Default::default(),
                     lifecycle: WorkerLifecycle::Running,
                 },
             )]),
@@ -738,6 +739,7 @@ mod tests {
                 agent_session: None,
                 worktree_path: None,
                 adopted: false,
+                launch_checkpoint: Default::default(),
                 lifecycle: WorkerLifecycle::Running,
             },
         );

--- a/src/run.rs
+++ b/src/run.rs
@@ -305,6 +305,7 @@ mod tests {
                 agent_session: None,
                 worktree_path: Some(PathBuf::from("/tmp/worktree")),
                 adopted: false,
+                launch_checkpoint: Default::default(),
                 lifecycle: WorkerLifecycle::Running,
             },
         );

--- a/src/run.rs
+++ b/src/run.rs
@@ -2,6 +2,7 @@
 
 use crate::reconcile::HookMetadata;
 use crate::types::{RunLifecycle, RunState};
+use fs4::FileExt;
 use serde::Deserialize;
 use serde_json::Value;
 use std::fs::{self, File, OpenOptions};
@@ -12,6 +13,7 @@ use thiserror::Error;
 
 const RUNS_DIR: &str = "runs";
 const RUN_FILE: &str = "run.toml";
+const RUN_LOCK_FILE: &str = ".run.toml.lock";
 const INBOX_DIR: &str = "inbox";
 const EVENTS_FILE: &str = "events.jsonl";
 
@@ -144,6 +146,43 @@ pub fn save_run_with_hook(run: &RunBoard, hook: &HookMetadata) -> Result<(), Run
         }
     }
     write_run_contents(&run.dir, &contents)
+}
+
+/// Serialize a fresh load-mutate-save transaction across plugin processes.
+///
+/// The dedicated lock file remains stable while `run.toml` is atomically
+/// replaced, so every cooperating writer locks the same inode.
+pub fn update_run_with_hook<T, E>(
+    run_dir: &Path,
+    update: impl FnOnce(&mut RunBoard, &mut HookMetadata) -> Result<T, E>,
+) -> Result<(RunBoard, T), E>
+where
+    E: From<RunError>,
+{
+    let lock_file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(run_dir.join(RUN_LOCK_FILE))
+        .map_err(RunError::from)?;
+    FileExt::lock(&lock_file).map_err(RunError::from)?;
+
+    let result = (|| {
+        let mut run = load_run(run_dir).map_err(E::from)?;
+        let mut hook = load_hook_metadata(run_dir).map_err(E::from)?;
+        let value = update(&mut run, &mut hook)?;
+        save_run_with_hook(&run, &hook).map_err(E::from)?;
+        Ok((run, value))
+    })();
+    let unlock = FileExt::unlock(&lock_file)
+        .map_err(RunError::from)
+        .map_err(E::from);
+    match (result, unlock) {
+        (Err(error), _) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Ok(value), Ok(())) => Ok(value),
+    }
 }
 
 fn write_run_contents(run_dir: &Path, contents: &str) -> Result<(), RunError> {

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -3,14 +3,14 @@
 use crate::agents_md::{render_agents_md, AgentsMdError};
 use crate::herdr::{HerdrApi, HerdrClient, HerdrError, PaneInfo, WaitOutcome};
 use crate::launcher::{launcher_entry, load_from_env, LauncherError};
-use crate::run::{create_run, save_run, RunBoard, RunError};
+use crate::run::{create_run, load_run, save_run, RunBoard, RunError};
 use crate::spec::{
     load_team_spec, spawn_command as dry_run_command, team_spec_from_agents, validate_team_spec,
     SpecError,
 };
 use crate::types::{
     current_herdr_session_identity, AgentsMdMode, LauncherEntry, LauncherTable, RunLifecycle,
-    RunState, TeamSpec, WorkerLifecycle, WorkerRunState, WorkerSpec,
+    RunState, TeamSpec, WorkerLaunchCheckpoint, WorkerLifecycle, WorkerRunState, WorkerSpec,
 };
 use std::collections::BTreeMap;
 use std::env;
@@ -18,6 +18,7 @@ use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 use thiserror::Error;
@@ -112,6 +113,7 @@ pub enum SpawnError {
 struct SpawnArguments {
     spec_path: Option<PathBuf>,
     agents: Option<String>,
+    resume: Option<PathBuf>,
 }
 
 struct SpawnContext {
@@ -157,7 +159,52 @@ pub fn spawn_command(args: &[String]) -> Result<(), SpawnError> {
     }
 
     let arguments = parse_spawn_arguments(args)?;
-    spawn_team(arguments.spec_path.as_deref(), arguments.agents.as_deref())
+    if let Some(run_dir) = arguments.resume {
+        resume_team(&run_dir)
+    } else {
+        spawn_team(arguments.spec_path.as_deref(), arguments.agents.as_deref())
+    }
+}
+
+pub fn resume_team(run_dir: &Path) -> Result<(), SpawnError> {
+    let current_dir = env::current_dir().map_err(|source| SpawnError::Io {
+        action: "read current directory",
+        path: PathBuf::from("."),
+        source,
+    })?;
+    let run_dir = absolutize(run_dir, &current_dir);
+    let launchers = load_from_env()?;
+    let herdr = HerdrClient::from_env();
+    let run = load_run(&run_dir)?;
+    if !run
+        .state
+        .workers
+        .values()
+        .any(|worker| worker.lifecycle == WorkerLifecycle::Pending)
+    {
+        println!(
+            "team run already has no pending workers; nothing to resume: {}",
+            run.dir.display()
+        );
+        return Ok(());
+    }
+    let run = resume_resolved(
+        run,
+        &launchers,
+        &herdr,
+        command_exists,
+        &ProcessSetupRunner,
+        AGENT_START_TIMEOUT,
+    )?;
+    if run
+        .state
+        .workers
+        .values()
+        .all(|worker| worker.lifecycle == WorkerLifecycle::Running)
+    {
+        println!("team run complete: {}", run.dir.display());
+    }
+    Ok(())
 }
 
 pub fn spawn_team(spec_path: Option<&Path>, agents: Option<&str>) -> Result<(), SpawnError> {
@@ -183,11 +230,23 @@ pub fn spawn_team(spec_path: Option<&Path>, agents: Option<&str>) -> Result<(), 
 fn parse_spawn_arguments(args: &[String]) -> Result<SpawnArguments, SpawnError> {
     let mut spec_path = None;
     let mut agents = None;
+    let mut resume = None;
     let mut index = 0;
 
     while index < args.len() {
         let argument = &args[index];
         match argument.as_str() {
+            "--resume" => {
+                index += 1;
+                let value = args.get(index).ok_or_else(|| {
+                    SpawnError::Arguments("--resume requires a run directory".to_owned())
+                })?;
+                if resume.replace(PathBuf::from(value)).is_some() {
+                    return Err(SpawnError::Arguments(
+                        "--resume may only be supplied once".to_owned(),
+                    ));
+                }
+            }
             "--agents" => {
                 index += 1;
                 let value = args.get(index).ok_or_else(|| {
@@ -217,7 +276,16 @@ fn parse_spawn_arguments(args: &[String]) -> Result<SpawnArguments, SpawnError> 
             "--agents and a team spec path are mutually exclusive".to_owned(),
         ));
     }
-    Ok(SpawnArguments { spec_path, agents })
+    if resume.is_some() && (agents.is_some() || spec_path.is_some()) {
+        return Err(SpawnError::Arguments(
+            "--resume is mutually exclusive with --agents and a team spec path".to_owned(),
+        ));
+    }
+    Ok(SpawnArguments {
+        spec_path,
+        agents,
+        resume,
+    })
 }
 
 fn set_agents(slot: &mut Option<String>, value: &str) -> Result<(), SpawnError> {
@@ -308,7 +376,7 @@ fn spawn_resolved<H, F>(
     command_available: F,
 ) -> Result<RunBoard, SpawnError>
 where
-    H: HerdrApi,
+    H: HerdrApi + Sync,
     F: Fn(&str) -> bool,
 {
     spawn_resolved_with_setup(
@@ -333,7 +401,7 @@ fn spawn_resolved_with_setup<H, F, S>(
     setup_runner: &S,
 ) -> Result<RunBoard, SpawnError>
 where
-    H: HerdrApi,
+    H: HerdrApi + Sync,
     F: Fn(&str) -> bool,
     S: SetupRunner,
 {
@@ -361,7 +429,7 @@ fn spawn_resolved_with_setup_and_agent_info_timeout<H, F, S>(
     agent_info_timeout: Duration,
 ) -> Result<RunBoard, SpawnError>
 where
-    H: HerdrApi,
+    H: HerdrApi + Sync,
     F: Fn(&str) -> bool,
     S: SetupRunner,
 {
@@ -381,6 +449,7 @@ where
                     agent_session: None,
                     worktree_path: None,
                     adopted: false,
+                    launch_checkpoint: WorkerLaunchCheckpoint::Pending,
                     lifecycle: WorkerLifecycle::Pending,
                 },
             )
@@ -415,16 +484,142 @@ where
         write_worker_protocol(&spec, worker, &run)?;
     }
 
-    for worker in &spec.workers {
-        if let Err(error) = launch_worker(worker, launchers, &mut run, herdr, agent_info_timeout) {
-            if let Some(worker_state) = run.state.workers.get_mut(&worker.name) {
-                worker_state.lifecycle = WorkerLifecycle::Failed;
-            }
-            save_run(&run)?;
-            return Err(error);
+    launch_workers(
+        spec.workers.clone(),
+        launchers,
+        run,
+        herdr,
+        agent_info_timeout,
+    )
+}
+
+fn resume_resolved<H, F, S>(
+    mut run: RunBoard,
+    launchers: &LauncherTable,
+    herdr: &H,
+    command_available: F,
+    setup_runner: &S,
+    agent_info_timeout: Duration,
+) -> Result<RunBoard, SpawnError>
+where
+    H: HerdrApi + Sync,
+    F: Fn(&str) -> bool,
+    S: SetupRunner,
+{
+    if !run
+        .state
+        .workers
+        .values()
+        .any(|worker| worker.lifecycle == WorkerLifecycle::Pending)
+    {
+        return Ok(run);
+    }
+    preflight(&run.state.spec, launchers, herdr, &command_available)?;
+    let pending = run
+        .state
+        .spec
+        .workers
+        .iter()
+        .filter(|worker| run.state.workers[&worker.name].lifecycle == WorkerLifecycle::Pending)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    for worker in &pending {
+        ensure_pending_resources(
+            &run.state.spec.clone(),
+            worker,
+            &mut run,
+            herdr,
+            setup_runner,
+        )?;
+    }
+    for worker in &pending {
+        let protocol = worker_protocol_path(&run, worker);
+        if !protocol.exists() {
+            write_worker_protocol(&run.state.spec, worker, &run)?;
         }
     }
 
+    launch_workers(pending, launchers, run, herdr, agent_info_timeout)
+}
+
+fn ensure_pending_resources<H: HerdrApi, S: SetupRunner>(
+    spec: &TeamSpec,
+    worker: &WorkerSpec,
+    run: &mut RunBoard,
+    herdr: &H,
+    setup_runner: &S,
+) -> Result<(), SpawnError> {
+    let pane_is_live = run.state.workers[&worker.name]
+        .pane_id
+        .as_deref()
+        .is_some_and(|pane_id| herdr.pane_get(pane_id).is_ok());
+    if pane_is_live {
+        return Ok(());
+    }
+
+    let cwd = if worker.worktree {
+        match run.state.workers[&worker.name].worktree_path.clone() {
+            Some(path) => path,
+            None => prepare_worker_cwd(spec, worker, run, herdr, setup_runner)?,
+        }
+    } else {
+        spec.cwd.clone()
+    };
+    let workspace = herdr
+        .workspace_create(&cwd, &worker.name)
+        .map_err(|source| worker_herdr(worker, "workspace recreate", source))?;
+    let state = run
+        .state
+        .workers
+        .get_mut(&worker.name)
+        .expect("resume worker exists in run state");
+    state.workspace_id = Some(workspace.workspace_id);
+    state.pane_id = Some(workspace.pane_id);
+    state.launch_checkpoint = WorkerLaunchCheckpoint::ResourcesReady;
+    save_run(run)?;
+    Ok(())
+}
+
+fn launch_workers<H: HerdrApi + Sync>(
+    workers: Vec<WorkerSpec>,
+    launchers: &LauncherTable,
+    run: RunBoard,
+    herdr: &H,
+    agent_info_timeout: Duration,
+) -> Result<RunBoard, SpawnError> {
+    let run = Arc::new(Mutex::new(run));
+    let results = thread::scope(|scope| {
+        workers
+            .iter()
+            .map(|worker| {
+                let run = Arc::clone(&run);
+                scope.spawn(move || {
+                    let result = launch_worker(worker, launchers, &run, herdr, agent_info_timeout);
+                    if result.is_err() {
+                        let mut run = run.lock().expect("run checkpoint lock");
+                        run.state
+                            .workers
+                            .get_mut(&worker.name)
+                            .expect("launch worker exists in run state")
+                            .lifecycle = WorkerLifecycle::Failed;
+                        save_run(&run)?;
+                    }
+                    result
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|handle| handle.join().expect("worker launch thread panicked"))
+            .collect::<Vec<_>>()
+    });
+    let run = Arc::try_unwrap(run)
+        .expect("all launch threads joined")
+        .into_inner()
+        .expect("run checkpoint lock");
+    if let Some(error) = results.into_iter().find_map(Result::err) {
+        return Err(error);
+    }
     Ok(run)
 }
 
@@ -510,6 +705,7 @@ fn allocate_worker_workspace<H: HerdrApi, S: SetupRunner>(
             .expect("run state is initialized from the same team spec");
         state.workspace_id = Some(workspace.workspace_id.clone());
         state.pane_id = Some(workspace.pane_id.clone());
+        state.launch_checkpoint = WorkerLaunchCheckpoint::ResourcesReady;
     }
     save_run(run)?;
     Ok(())
@@ -576,16 +772,21 @@ fn run_setup_commands<S: SetupRunner>(
 fn launch_worker<H: HerdrApi>(
     worker: &WorkerSpec,
     launchers: &LauncherTable,
-    run: &mut RunBoard,
+    run: &Arc<Mutex<RunBoard>>,
     herdr: &H,
     agent_info_timeout: Duration,
 ) -> Result<(), SpawnError> {
-    let pane_id = run
-        .state
-        .workers
-        .get(&worker.name)
-        .and_then(|state| state.pane_id.clone())
-        .expect("workspace allocation records a root pane before launch");
+    let (pane_id, protocol_path) = {
+        let run = run.lock().expect("run checkpoint lock");
+        (
+            run.state
+                .workers
+                .get(&worker.name)
+                .and_then(|state| state.pane_id.clone())
+                .expect("workspace allocation records a root pane before launch"),
+            worker_protocol_path(&run, worker),
+        )
+    };
     let launcher = launcher_entry(launchers, &worker.agent)?;
     herdr
         .pane_run(&pane_id, &shell_join(&launcher.command))
@@ -599,31 +800,32 @@ fn launch_worker<H: HerdrApi>(
         "agent startup",
     )?;
 
-    let pane = wait_for_agent_info(herdr, worker, &pane_id, agent_info_timeout)?;
-    let state = run
-        .state
-        .workers
-        .get_mut(&worker.name)
-        .expect("run state is initialized from the same team spec");
-    state.agent_id = pane.agent_id.clone();
-    state.agent_session = pane.agent_session.clone();
-    save_run(run)?;
+    let prompt = launch_prompt(worker, launcher, &protocol_path);
+    submit_worker_prompt(herdr, worker, &pane_id, &prompt, launcher.submit_verify)?;
 
-    let prompt = launch_prompt(worker, launcher, &worker_protocol_path(run, worker));
-    submit_worker_prompt(
-        herdr,
-        worker,
-        &pane.pane_id,
-        &prompt,
-        launcher.submit_verify,
-    )?;
+    {
+        let mut run = run.lock().expect("run checkpoint lock");
+        let state = run
+            .state
+            .workers
+            .get_mut(&worker.name)
+            .expect("run state is initialized from the same team spec");
+        state.launch_checkpoint = WorkerLaunchCheckpoint::BriefSubmitted;
+        state.lifecycle = WorkerLifecycle::Running;
+        save_run(&run)?;
+    }
 
-    run.state
-        .workers
-        .get_mut(&worker.name)
-        .expect("run state is initialized from the same team spec")
-        .lifecycle = WorkerLifecycle::Running;
-    save_run(run)?;
+    if let Some(pane) = wait_for_agent_info(herdr, worker, &pane_id, agent_info_timeout)? {
+        let mut run = run.lock().expect("run checkpoint lock");
+        let state = run
+            .state
+            .workers
+            .get_mut(&worker.name)
+            .expect("run state is initialized from the same team spec");
+        state.agent_id = pane.agent_id;
+        state.agent_session = pane.agent_session;
+        save_run(&run)?;
+    }
     Ok(())
 }
 
@@ -808,26 +1010,34 @@ fn wait_for_agent_info<H: HerdrApi>(
     worker: &WorkerSpec,
     pane_id: &str,
     timeout: Duration,
-) -> Result<PaneInfo, SpawnError> {
+) -> Result<Option<PaneInfo>, SpawnError> {
     let started = Instant::now();
     loop {
-        let pane = herdr
-            .pane_get(pane_id)
-            .map_err(|source| worker_herdr(worker, "agent detection", source))?;
+        let pane = match herdr.pane_get(pane_id) {
+            Ok(pane) => pane,
+            Err(error) => {
+                eprintln!(
+                    "warning: worker '{}' was briefed in pane '{}', but lazy agent info failed: {}",
+                    worker.name, pane_id, error
+                );
+                return Ok(None);
+            }
+        };
         if pane.agent.is_some() && pane.agent_id.is_some() {
-            return Ok(pane);
+            return Ok(Some(pane));
         }
 
         let remaining = timeout.saturating_sub(started.elapsed());
         if remaining.is_zero() {
             if pane.agent.is_none() {
-                return Err(SpawnError::AgentNotDetected {
-                    worker: worker.name.clone(),
-                    pane_id: pane_id.to_owned(),
-                });
+                eprintln!(
+                    "warning: worker '{}' was briefed in pane '{}', but Herdr did not report agent info before timeout",
+                    worker.name, pane_id
+                );
+                return Ok(None);
             }
             eprintln!("{}", missing_agent_id_warning(worker, pane_id));
-            return Ok(pane);
+            return Ok(None);
         }
         thread::sleep(Duration::from_millis(100).min(remaining));
     }
@@ -1042,6 +1252,7 @@ mod tests {
             SpawnArguments {
                 spec_path: None,
                 agents: Some("claude,codex".to_owned()),
+                resume: None,
             }
         );
         assert_eq!(
@@ -1049,8 +1260,22 @@ mod tests {
             SpawnArguments {
                 spec_path: Some(PathBuf::from("team.toml")),
                 agents: None,
+                resume: None,
             }
         );
+        assert_eq!(
+            parse_spawn_arguments(&["--resume".to_owned(), "/tmp/run-dir".to_owned(),]).unwrap(),
+            SpawnArguments {
+                spec_path: None,
+                agents: None,
+                resume: Some(PathBuf::from("/tmp/run-dir")),
+            }
+        );
+        assert!(parse_spawn_arguments(&[
+            "--resume=/tmp/run-dir".to_owned(),
+            "team.toml".to_owned(),
+        ])
+        .is_err());
     }
 
     #[test]
@@ -1482,14 +1707,14 @@ mod tests {
     }
 
     #[test]
-    fn no_agent_at_timeout_remains_a_hard_per_worker_failure() {
+    fn missing_post_brief_agent_info_does_not_fail_the_running_worker() {
         let temp = TempDir::new();
         let state_dir = temp.path().join("state");
         let fake = FakeHerdr::default();
         fake.omit_agent.set(true);
         let setup = FakeSetupRunner::default();
 
-        let error = spawn_resolved_with_setup_and_agent_info_timeout(
+        let run = spawn_resolved_with_setup_and_agent_info_timeout(
             team(
                 temp.path(),
                 vec![worker(temp.path(), "missing-agent", "claude")],
@@ -1502,21 +1727,27 @@ mod tests {
             &setup,
             Duration::ZERO,
         )
-        .expect_err("undetected agent must fail the worker");
+        .expect("optional post-brief identity must not fail the worker");
 
-        assert!(matches!(
-            error,
-            SpawnError::AgentNotDetected {
-                ref worker,
-                ref pane_id,
-            } if worker == "missing-agent" && pane_id == "pane-1"
-        ));
-        let run = load_run(&only_run_dir(&state_dir)).expect("load failed agent run");
+        let run = load_run(&run.dir).expect("load running agent run");
         assert_eq!(
             run.state.workers["missing-agent"].lifecycle,
-            WorkerLifecycle::Failed
+            WorkerLifecycle::Running
         );
         assert_eq!(run.state.workers["missing-agent"].agent_id, None);
+        let calls = fake.calls();
+        let brief = calls
+            .iter()
+            .position(|call| call.starts_with("pane_run:pane-1:Read your brief"))
+            .expect("brief submission");
+        let identity = calls
+            .iter()
+            .position(|call| call == "pane_get:pane-1")
+            .expect("lazy identity lookup");
+        assert!(
+            brief < identity,
+            "agent info must be fetched after briefing"
+        );
     }
 
     #[test]
@@ -1529,8 +1760,211 @@ mod tests {
         let pane = wait_for_agent_info(&fake, &worker, "pane-1", Duration::from_millis(500))
             .expect("second pane read should include the opaque ID");
 
-        assert_eq!(pane.agent_id.as_deref(), Some("agent-session-pane-1"));
+        assert_eq!(
+            pane.and_then(|pane| pane.agent_id).as_deref(),
+            Some("agent-session-pane-1")
+        );
         assert_eq!(fake.calls(), ["pane_get:pane-1", "pane_get:pane-1"]);
+    }
+
+    #[test]
+    fn resume_launches_pending_worker_and_leaves_running_worker_untouched() {
+        let temp = TempDir::new();
+        let state_dir = temp.path().join("state");
+        let fake = FakeHerdr::default();
+        let setup = FakeSetupRunner::default();
+        let run = spawn_resolved(
+            team(
+                temp.path(),
+                vec![
+                    worker(temp.path(), "running", "claude"),
+                    worker(temp.path(), "pending", "codex"),
+                ],
+            ),
+            &launchers(),
+            &state_dir,
+            "god-pane".to_owned(),
+            &fake,
+            command_is_available,
+        )
+        .expect("seed complete run");
+        let mut partial = load_run(&run.dir).expect("load seed run");
+        let pending = partial.state.workers.get_mut("pending").unwrap();
+        pending.lifecycle = WorkerLifecycle::Pending;
+        pending.launch_checkpoint = WorkerLaunchCheckpoint::ResourcesReady;
+        pending.agent_id = None;
+        pending.agent_session = None;
+        save_run(&partial).expect("persist half-launched checkpoint");
+        fake.calls.borrow_mut().clear();
+
+        let resumed = resume_resolved(
+            partial,
+            &launchers(),
+            &fake,
+            command_is_available,
+            &setup,
+            Duration::ZERO,
+        )
+        .expect("resume pending worker");
+
+        assert_eq!(
+            resumed.state.workers["running"].lifecycle,
+            WorkerLifecycle::Running
+        );
+        assert_eq!(
+            resumed.state.workers["pending"].lifecycle,
+            WorkerLifecycle::Running
+        );
+        let calls = fake.calls();
+        assert!(calls.iter().any(|call| call == "pane_run:pane-2:'codex'"));
+        assert!(!calls.iter().any(|call| call == "pane_run:pane-1:'claude'"));
+    }
+
+    #[test]
+    fn resume_complete_run_is_a_no_op() {
+        let temp = TempDir::new();
+        let fake = FakeHerdr::default();
+        let setup = FakeSetupRunner::default();
+        let run = spawn_resolved(
+            team(temp.path(), vec![worker(temp.path(), "running", "claude")]),
+            &launchers(),
+            &temp.path().join("state"),
+            "god-pane".to_owned(),
+            &fake,
+            command_is_available,
+        )
+        .expect("seed complete run");
+        fake.calls.borrow_mut().clear();
+
+        let resumed = resume_resolved(
+            run,
+            &launchers(),
+            &fake,
+            command_is_available,
+            &setup,
+            Duration::ZERO,
+        )
+        .expect("complete resume is harmless");
+
+        assert!(fake.calls().is_empty());
+        assert_eq!(
+            resumed.state.workers["running"].lifecycle,
+            WorkerLifecycle::Running
+        );
+    }
+
+    #[test]
+    fn resume_recreates_missing_pending_pane_instead_of_hanging() {
+        let temp = TempDir::new();
+        let state_dir = temp.path().join("state");
+        let fake = FakeHerdr::default();
+        let setup = FakeSetupRunner::default();
+        let run = spawn_resolved(
+            team(temp.path(), vec![worker(temp.path(), "pending", "claude")]),
+            &launchers(),
+            &state_dir,
+            "god-pane".to_owned(),
+            &fake,
+            command_is_available,
+        )
+        .expect("seed complete run");
+        let mut partial = load_run(&run.dir).expect("load seed run");
+        partial.state.workers.get_mut("pending").unwrap().lifecycle = WorkerLifecycle::Pending;
+        partial
+            .state
+            .workers
+            .get_mut("pending")
+            .unwrap()
+            .launch_checkpoint = WorkerLaunchCheckpoint::ResourcesReady;
+        save_run(&partial).expect("persist pending worker");
+        fake.missing_panes.borrow_mut().insert("pane-1".to_owned());
+        fake.calls.borrow_mut().clear();
+
+        let resumed = resume_resolved(
+            partial,
+            &launchers(),
+            &fake,
+            command_is_available,
+            &setup,
+            Duration::ZERO,
+        )
+        .expect("missing pane is recreated");
+
+        assert_eq!(
+            resumed.state.workers["pending"].pane_id.as_deref(),
+            Some("pane-2")
+        );
+        assert!(fake
+            .calls()
+            .iter()
+            .any(|call| call.starts_with("workspace_create:pending:")));
+    }
+
+    #[test]
+    fn parallel_launches_serialize_complete_checkpoints() {
+        let temp = TempDir::new();
+        let state_dir = temp.path().join("state");
+        let fake = FakeHerdr::default();
+        *fake.launch_barrier.borrow_mut() = Some(Arc::new(std::sync::Barrier::new(3)));
+
+        let run = spawn_resolved(
+            team(
+                temp.path(),
+                vec![
+                    worker(temp.path(), "one", "claude"),
+                    worker(temp.path(), "two", "codex"),
+                    worker(temp.path(), "three", "claude"),
+                ],
+            ),
+            &launchers(),
+            &state_dir,
+            "god-pane".to_owned(),
+            &fake,
+            command_is_available,
+        )
+        .expect("all launch threads meet at barrier");
+
+        let persisted = load_run(&run.dir).expect("run.toml remains parseable");
+        assert!(persisted.state.workers.values().all(|worker| {
+            worker.lifecycle == WorkerLifecycle::Running
+                && worker.launch_checkpoint == WorkerLaunchCheckpoint::BriefSubmitted
+        }));
+    }
+
+    #[test]
+    fn lazy_agent_info_persists_identity_after_brief_submission() {
+        let temp = TempDir::new();
+        let fake = FakeHerdr::default();
+        fake.agent_id_delays.set(1);
+
+        let run = spawn_resolved_with_setup_and_agent_info_timeout(
+            team(temp.path(), vec![worker(temp.path(), "lazy", "claude")]),
+            &launchers(),
+            &temp.path().join("state"),
+            "god-pane".to_owned(),
+            &fake,
+            &command_is_available,
+            &FakeSetupRunner::default(),
+            Duration::from_millis(500),
+        )
+        .expect("delayed identity arrives after brief");
+
+        let calls = fake.calls();
+        let brief = calls
+            .iter()
+            .position(|call| call.starts_with("pane_run:pane-1:Read your brief"))
+            .unwrap();
+        let first_info = calls
+            .iter()
+            .position(|call| call == "pane_get:pane-1")
+            .unwrap();
+        assert!(brief < first_info);
+        assert_eq!(
+            load_run(&run.dir).unwrap().state.workers["lazy"]
+                .agent_id
+                .as_deref(),
+            Some("agent-session-pane-1")
+        );
     }
 
     #[test]

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -3,7 +3,7 @@
 use crate::agents_md::{render_agents_md, AgentsMdError};
 use crate::herdr::{HerdrApi, HerdrClient, HerdrError, PaneInfo, WaitOutcome};
 use crate::launcher::{launcher_entry, load_from_env, LauncherError};
-use crate::run::{create_run, load_run, save_run, RunBoard, RunError};
+use crate::run::{create_run, load_run, RunBoard, RunError};
 use crate::spec::{
     load_team_spec, spawn_command as dry_run_command, team_spec_from_agents, validate_team_spec,
     SpecError,
@@ -105,8 +105,8 @@ pub enum SpawnError {
         status: &'static str,
         step: &'static str,
     },
-    #[error("worker '{worker}' launched in pane '{pane_id}', but Herdr did not detect an agent")]
-    AgentNotDetected { worker: String, pane_id: String },
+    #[error("worker '{worker}' recorded worktree is missing or not a directory: `{path}`")]
+    MissingWorktree { worker: String, path: PathBuf },
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -176,14 +176,9 @@ pub fn resume_team(run_dir: &Path) -> Result<(), SpawnError> {
     let launchers = load_from_env()?;
     let herdr = HerdrClient::from_env();
     let run = load_run(&run_dir)?;
-    if !run
-        .state
-        .workers
-        .values()
-        .any(|worker| worker.lifecycle == WorkerLifecycle::Pending)
-    {
+    if resume_workers(&run).is_empty() {
         println!(
-            "team run already has no pending workers; nothing to resume: {}",
+            "team run already has no spawn-owned pending workers; nothing to resume: {}",
             run.dir.display()
         );
         return Ok(());
@@ -469,10 +464,9 @@ where
     for worker in &spec.workers {
         if let Err(error) = allocate_worker_workspace(&spec, worker, &mut run, herdr, setup_runner)
         {
-            if let Some(worker_state) = run.state.workers.get_mut(&worker.name) {
-                worker_state.lifecycle = WorkerLifecycle::Failed;
-            }
-            save_run(&run)?;
+            update_worker_state(&mut run, &worker.name, |state| {
+                state.lifecycle = WorkerLifecycle::Failed;
+            })?;
             return Err(error);
         }
     }
@@ -490,6 +484,7 @@ where
         run,
         herdr,
         agent_info_timeout,
+        false,
     )
 }
 
@@ -506,23 +501,13 @@ where
     F: Fn(&str) -> bool,
     S: SetupRunner,
 {
-    if !run
-        .state
-        .workers
-        .values()
-        .any(|worker| worker.lifecycle == WorkerLifecycle::Pending)
-    {
+    let pending = resume_workers(&run);
+    if pending.is_empty() {
         return Ok(run);
     }
-    preflight(&run.state.spec, launchers, herdr, &command_available)?;
-    let pending = run
-        .state
-        .spec
-        .workers
-        .iter()
-        .filter(|worker| run.state.workers[&worker.name].lifecycle == WorkerLifecycle::Pending)
-        .cloned()
-        .collect::<Vec<_>>();
+    let mut pending_spec = run.state.spec.clone();
+    pending_spec.workers = pending.clone();
+    preflight(&pending_spec, launchers, herdr, &command_available)?;
 
     for worker in &pending {
         ensure_pending_resources(
@@ -540,7 +525,39 @@ where
         }
     }
 
-    launch_workers(pending, launchers, run, herdr, agent_info_timeout)
+    launch_workers(pending, launchers, run, herdr, agent_info_timeout, true)
+}
+
+fn resume_workers(run: &RunBoard) -> Vec<WorkerSpec> {
+    run.state
+        .spec
+        .workers
+        .iter()
+        .filter(|worker| {
+            let state = &run.state.workers[&worker.name];
+            state.lifecycle == WorkerLifecycle::Pending && !state.adopted
+        })
+        .cloned()
+        .collect()
+}
+
+fn update_worker_state(
+    run: &mut RunBoard,
+    worker_name: &str,
+    update: impl FnOnce(&mut WorkerRunState),
+) -> Result<(), SpawnError> {
+    let (fresh, ()) =
+        crate::run::update_run_with_hook(&run.dir, |fresh, _| -> Result<(), SpawnError> {
+            let worker = fresh
+                .state
+                .workers
+                .get_mut(worker_name)
+                .expect("spawn worker exists in persisted run state");
+            update(worker);
+            Ok(())
+        })?;
+    *run = fresh;
+    Ok(())
 }
 
 fn ensure_pending_resources<H: HerdrApi, S: SetupRunner>(
@@ -555,12 +572,21 @@ fn ensure_pending_resources<H: HerdrApi, S: SetupRunner>(
         .as_deref()
         .is_some_and(|pane_id| herdr.pane_get(pane_id).is_ok());
     if pane_is_live {
+        update_worker_state(run, &worker.name, |state| {
+            state.launch_checkpoint = WorkerLaunchCheckpoint::ResourcesReady;
+        })?;
         return Ok(());
     }
 
     let cwd = if worker.worktree {
         match run.state.workers[&worker.name].worktree_path.clone() {
-            Some(path) => path,
+            Some(path) if path.is_dir() => path,
+            Some(path) => {
+                return Err(SpawnError::MissingWorktree {
+                    worker: worker.name.clone(),
+                    path,
+                })
+            }
             None => prepare_worker_cwd(spec, worker, run, herdr, setup_runner)?,
         }
     } else {
@@ -569,15 +595,11 @@ fn ensure_pending_resources<H: HerdrApi, S: SetupRunner>(
     let workspace = herdr
         .workspace_create(&cwd, &worker.name)
         .map_err(|source| worker_herdr(worker, "workspace recreate", source))?;
-    let state = run
-        .state
-        .workers
-        .get_mut(&worker.name)
-        .expect("resume worker exists in run state");
-    state.workspace_id = Some(workspace.workspace_id);
-    state.pane_id = Some(workspace.pane_id);
-    state.launch_checkpoint = WorkerLaunchCheckpoint::ResourcesReady;
-    save_run(run)?;
+    update_worker_state(run, &worker.name, |state| {
+        state.workspace_id = Some(workspace.workspace_id);
+        state.pane_id = Some(workspace.pane_id);
+        state.launch_checkpoint = WorkerLaunchCheckpoint::ResourcesReady;
+    })?;
     Ok(())
 }
 
@@ -587,6 +609,7 @@ fn launch_workers<H: HerdrApi + Sync>(
     run: RunBoard,
     herdr: &H,
     agent_info_timeout: Duration,
+    resume_existing: bool,
 ) -> Result<RunBoard, SpawnError> {
     let run = Arc::new(Mutex::new(run));
     let results = thread::scope(|scope| {
@@ -595,15 +618,30 @@ fn launch_workers<H: HerdrApi + Sync>(
             .map(|worker| {
                 let run = Arc::clone(&run);
                 scope.spawn(move || {
-                    let result = launch_worker(worker, launchers, &run, herdr, agent_info_timeout);
+                    let result = launch_worker(
+                        worker,
+                        launchers,
+                        &run,
+                        herdr,
+                        agent_info_timeout,
+                        resume_existing,
+                    );
                     if result.is_err() {
                         let mut run = run.lock().expect("run checkpoint lock");
-                        run.state
-                            .workers
-                            .get_mut(&worker.name)
-                            .expect("launch worker exists in run state")
-                            .lifecycle = WorkerLifecycle::Failed;
-                        save_run(&run)?;
+                        if let Err(save_error) = update_worker_state(
+                            &mut run,
+                            &worker.name,
+                            |state| {
+                                if state.lifecycle == WorkerLifecycle::Pending {
+                                    state.lifecycle = WorkerLifecycle::Failed;
+                                }
+                            },
+                        ) {
+                            eprintln!(
+                                "warning: failed to persist worker '{}' launch failure: {save_error}",
+                                worker.name
+                            );
+                        }
                     }
                     result
                 })
@@ -697,17 +735,11 @@ fn allocate_worker_workspace<H: HerdrApi, S: SetupRunner>(
     let workspace = herdr
         .workspace_create(&cwd, &worker.name)
         .map_err(|source| worker_herdr(worker, "workspace create", source))?;
-    {
-        let state = run
-            .state
-            .workers
-            .get_mut(&worker.name)
-            .expect("run state is initialized from the same team spec");
+    update_worker_state(run, &worker.name, |state| {
         state.workspace_id = Some(workspace.workspace_id.clone());
         state.pane_id = Some(workspace.pane_id.clone());
         state.launch_checkpoint = WorkerLaunchCheckpoint::ResourcesReady;
-    }
-    save_run(run)?;
+    })?;
     Ok(())
 }
 
@@ -729,12 +761,9 @@ fn prepare_worker_cwd<H: HerdrApi, S: SetupRunner>(
     let worktree = herdr
         .worktree_create(&spec.cwd, branch)
         .map_err(|source| worker_herdr(worker, "worktree create", source))?;
-    run.state
-        .workers
-        .get_mut(&worker.name)
-        .expect("run state is initialized from the same team spec")
-        .worktree_path = Some(worktree.path.clone());
-    save_run(run)?;
+    update_worker_state(run, &worker.name, |state| {
+        state.worktree_path = Some(worktree.path.clone());
+    })?;
 
     run_setup_commands(worker, &worktree.path, &spec.setup, setup_runner)?;
     Ok(worktree.path)
@@ -775,6 +804,7 @@ fn launch_worker<H: HerdrApi>(
     run: &Arc<Mutex<RunBoard>>,
     herdr: &H,
     agent_info_timeout: Duration,
+    resume_existing: bool,
 ) -> Result<(), SpawnError> {
     let (pane_id, protocol_path) = {
         let run = run.lock().expect("run checkpoint lock");
@@ -788,43 +818,45 @@ fn launch_worker<H: HerdrApi>(
         )
     };
     let launcher = launcher_entry(launchers, &worker.agent)?;
-    herdr
-        .pane_run(&pane_id, &shell_join(&launcher.command))
-        .map_err(|source| worker_herdr(worker, "agent launch", source))?;
-    wait_for(
-        herdr,
-        worker,
-        &pane_id,
-        "idle",
-        AGENT_START_TIMEOUT,
-        "agent startup",
-    )?;
+    let agent_already_running = resume_existing
+        && herdr
+            .pane_get(&pane_id)
+            .map_err(|source| worker_herdr(worker, "resume agent detection", source))?
+            .agent
+            .is_some();
+    if !agent_already_running {
+        herdr
+            .pane_run(&pane_id, &shell_join(&launcher.command))
+            .map_err(|source| worker_herdr(worker, "agent launch", source))?;
+        wait_for(
+            herdr,
+            worker,
+            &pane_id,
+            "idle",
+            AGENT_START_TIMEOUT,
+            "agent startup",
+        )?;
+    }
 
     let prompt = launch_prompt(worker, launcher, &protocol_path);
     submit_worker_prompt(herdr, worker, &pane_id, &prompt, launcher.submit_verify)?;
 
     {
         let mut run = run.lock().expect("run checkpoint lock");
-        let state = run
-            .state
-            .workers
-            .get_mut(&worker.name)
-            .expect("run state is initialized from the same team spec");
-        state.launch_checkpoint = WorkerLaunchCheckpoint::BriefSubmitted;
-        state.lifecycle = WorkerLifecycle::Running;
-        save_run(&run)?;
+        update_worker_state(&mut run, &worker.name, |state| {
+            state.launch_checkpoint = WorkerLaunchCheckpoint::BriefSubmitted;
+            if state.lifecycle == WorkerLifecycle::Pending {
+                state.lifecycle = WorkerLifecycle::Running;
+            }
+        })?;
     }
 
     if let Some(pane) = wait_for_agent_info(herdr, worker, &pane_id, agent_info_timeout)? {
         let mut run = run.lock().expect("run checkpoint lock");
-        let state = run
-            .state
-            .workers
-            .get_mut(&worker.name)
-            .expect("run state is initialized from the same team spec");
-        state.agent_id = pane.agent_id;
-        state.agent_session = pane.agent_session;
-        save_run(&run)?;
+        update_worker_state(&mut run, &worker.name, |state| {
+            state.agent_id = pane.agent_id;
+            state.agent_session = pane.agent_session;
+        })?;
     }
     Ok(())
 }
@@ -1107,7 +1139,7 @@ mod tests {
     use super::*;
     use crate::herdr::test_support::{BriefOrder, FakeHerdr};
     use crate::launcher::default_launcher_table;
-    use crate::run::load_run;
+    use crate::run::{load_run, save_run};
     use crate::types::{GodSpec, Topology};
     use std::cell::RefCell;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -1816,8 +1848,203 @@ mod tests {
             WorkerLifecycle::Running
         );
         let calls = fake.calls();
-        assert!(calls.iter().any(|call| call == "pane_run:pane-2:'codex'"));
+        assert!(calls
+            .iter()
+            .any(|call| { call.starts_with("pane_run:pane-2:Read your brief at ") }));
+        assert!(!calls.iter().any(|call| call == "pane_run:pane-2:'codex'"));
         assert!(!calls.iter().any(|call| call == "pane_run:pane-1:'claude'"));
+    }
+
+    #[test]
+    fn resume_launches_cli_when_live_pending_pane_has_no_agent() {
+        let temp = TempDir::new();
+        let state_dir = temp.path().join("state");
+        let fake = FakeHerdr::default();
+        let setup = FakeSetupRunner::default();
+        let run = spawn_resolved(
+            team(temp.path(), vec![worker(temp.path(), "pending", "codex")]),
+            &launchers(),
+            &state_dir,
+            "god-pane".to_owned(),
+            &fake,
+            command_is_available,
+        )
+        .expect("seed complete run");
+        let mut partial = load_run(&run.dir).unwrap();
+        partial.state.workers.get_mut("pending").unwrap().lifecycle = WorkerLifecycle::Pending;
+        save_run(&partial).unwrap();
+        fake.omit_agent.set(true);
+        fake.calls.borrow_mut().clear();
+
+        resume_resolved(
+            partial,
+            &launchers(),
+            &fake,
+            command_is_available,
+            &setup,
+            Duration::ZERO,
+        )
+        .expect("resume unlaunched pane");
+
+        assert!(fake
+            .calls()
+            .iter()
+            .any(|call| call == "pane_run:pane-1:'codex'"));
+    }
+
+    #[test]
+    fn resume_skips_pending_adopted_worker_without_brief_preflight() {
+        let temp = TempDir::new();
+        let fake = FakeHerdr::default();
+        let setup = FakeSetupRunner::default();
+        let run = spawn_resolved(
+            team(temp.path(), vec![worker(temp.path(), "adopted", "claude")]),
+            &launchers(),
+            &temp.path().join("state"),
+            "god-pane".to_owned(),
+            &fake,
+            command_is_available,
+        )
+        .unwrap();
+        let mut partial = load_run(&run.dir).unwrap();
+        let state = partial.state.workers.get_mut("adopted").unwrap();
+        state.lifecycle = WorkerLifecycle::Pending;
+        state.adopted = true;
+        partial.state.spec.workers[0].brief = temp.path().join("missing-brief.md");
+        save_run(&partial).unwrap();
+        fake.calls.borrow_mut().clear();
+
+        let resumed = resume_resolved(
+            partial,
+            &launchers(),
+            &fake,
+            command_is_available,
+            &setup,
+            Duration::ZERO,
+        )
+        .expect("adopted pending worker is not spawn-resumed");
+
+        assert!(fake.calls().is_empty());
+        assert!(resumed.state.workers["adopted"].adopted);
+        assert_eq!(
+            resumed.state.workers["adopted"].lifecycle,
+            WorkerLifecycle::Pending
+        );
+    }
+
+    #[test]
+    fn resume_preflight_ignores_running_workers_missing_brief() {
+        let temp = TempDir::new();
+        let fake = FakeHerdr::default();
+        let setup = FakeSetupRunner::default();
+        let run = spawn_resolved(
+            team(
+                temp.path(),
+                vec![
+                    worker(temp.path(), "running", "claude"),
+                    worker(temp.path(), "pending", "codex"),
+                ],
+            ),
+            &launchers(),
+            &temp.path().join("state"),
+            "god-pane".to_owned(),
+            &fake,
+            command_is_available,
+        )
+        .unwrap();
+        let mut partial = load_run(&run.dir).unwrap();
+        partial.state.workers.get_mut("pending").unwrap().lifecycle = WorkerLifecycle::Pending;
+        fs::remove_file(&partial.state.spec.workers[0].brief).unwrap();
+        save_run(&partial).unwrap();
+
+        resume_resolved(
+            partial,
+            &launchers(),
+            &fake,
+            command_is_available,
+            &setup,
+            Duration::ZERO,
+        )
+        .expect("running worker files are outside resume preflight");
+    }
+
+    #[test]
+    fn resume_names_missing_recorded_worktree_before_workspace_create() {
+        let temp = TempDir::new();
+        let state_dir = temp.path().join("state");
+        let fake = FakeHerdr::default();
+        let setup = FakeSetupRunner::default();
+        let mut builder = worker(temp.path(), "builder", "claude");
+        builder.worktree = true;
+        builder.branch = Some("feat/builder".to_owned());
+        let run = spawn_resolved_with_setup(
+            team(temp.path(), vec![builder]),
+            &launchers(),
+            &state_dir,
+            "god-pane".to_owned(),
+            &fake,
+            &command_is_available,
+            &setup,
+        )
+        .unwrap();
+        let mut partial = load_run(&run.dir).unwrap();
+        partial.state.workers.get_mut("builder").unwrap().lifecycle = WorkerLifecycle::Pending;
+        let missing = partial.state.workers["builder"]
+            .worktree_path
+            .clone()
+            .unwrap();
+        save_run(&partial).unwrap();
+        fake.missing_panes.borrow_mut().insert("pane-1".to_owned());
+
+        let error = resume_resolved(
+            partial,
+            &launchers(),
+            &fake,
+            command_is_available,
+            &setup,
+            Duration::ZERO,
+        )
+        .expect_err("missing recorded worktree must be named")
+        .to_string();
+
+        assert!(error.contains("worker 'builder'"));
+        assert!(error.contains(&missing.display().to_string()));
+    }
+
+    #[test]
+    fn spawn_worker_update_preserves_fresher_hook_lifecycle() {
+        let temp = TempDir::new();
+        let fake = FakeHerdr::default();
+        let run = spawn_resolved(
+            team(temp.path(), vec![worker(temp.path(), "worker", "claude")]),
+            &launchers(),
+            &temp.path().join("state"),
+            "god-pane".to_owned(),
+            &fake,
+            command_is_available,
+        )
+        .unwrap();
+        let mut stale_spawn = run.clone();
+        crate::run::update_run_with_hook(&run.dir, |fresh, _| -> Result<(), SpawnError> {
+            fresh.state.workers.get_mut("worker").unwrap().lifecycle = WorkerLifecycle::Orphaned;
+            Ok(())
+        })
+        .unwrap();
+
+        update_worker_state(&mut stale_spawn, "worker", |state| {
+            state.agent_id = Some("late-agent-id".to_owned());
+        })
+        .unwrap();
+
+        let persisted = load_run(&run.dir).unwrap();
+        assert_eq!(
+            persisted.state.workers["worker"].lifecycle,
+            WorkerLifecycle::Orphaned
+        );
+        assert_eq!(
+            persisted.state.workers["worker"].agent_id.as_deref(),
+            Some("late-agent-id")
+        );
     }
 
     #[test]

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1105,7 +1105,7 @@ fn is_executable(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::herdr::test_support::FakeHerdr;
+    use crate::herdr::test_support::{BriefOrder, FakeHerdr};
     use crate::launcher::default_launcher_table;
     use crate::run::load_run;
     use crate::types::{GodSpec, Topology};
@@ -1987,6 +1987,7 @@ mod tests {
         fs::write(&authored_agents, "# Authored repository instructions\n")
             .expect("write authored AGENTS.md");
         let fake = FakeHerdr::default();
+        *fake.brief_order.borrow_mut() = Some(Arc::new(BriefOrder::new(["pane-2", "pane-1"])));
         let spec = team(
             temp.path(),
             vec![
@@ -2016,21 +2017,24 @@ mod tests {
             .into_iter()
             .filter_map(|call| {
                 let (_, path) = call.split_once(marker)?;
-                Some(PathBuf::from(path.strip_suffix('.').unwrap_or(path)))
+                let path = PathBuf::from(path.strip_suffix('.').unwrap_or(path));
+                let worker_name = path.file_stem()?.to_str()?.to_owned();
+                Some((worker_name, path))
             })
-            .collect::<Vec<_>>();
+            .collect::<BTreeMap<_, _>>();
         assert_eq!(
             protocol_paths.len(),
             2,
             "every launcher mode needs a pointer"
         );
-        assert_ne!(protocol_paths[0], protocol_paths[1]);
+        assert_ne!(
+            protocol_paths["pointer-worker"],
+            protocol_paths["native-worker"]
+        );
         let running_binary = env::current_exe().expect("resolve test executable");
 
-        for (path, worker_name) in protocol_paths
-            .iter()
-            .zip(["pointer-worker", "native-worker"])
-        {
+        for worker_name in ["pointer-worker", "native-worker"] {
+            let path = &protocol_paths[worker_name];
             assert!(path.is_absolute());
             assert!(path.starts_with(&run.dir));
             let protocol = fs::read_to_string(path).expect("read generated protocol");

--- a/src/status_kill.rs
+++ b/src/status_kill.rs
@@ -665,6 +665,7 @@ mod tests {
             agent_session: None,
             worktree_path: Some(worktree_root.join(worktree)),
             adopted: false,
+            launch_checkpoint: Default::default(),
             lifecycle: WorkerLifecycle::Running,
         };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -108,7 +108,19 @@ pub struct WorkerRunState {
     pub worktree_path: Option<PathBuf>,
     #[serde(default)]
     pub adopted: bool,
+    #[serde(default)]
+    pub launch_checkpoint: WorkerLaunchCheckpoint,
     pub lifecycle: WorkerLifecycle,
+}
+
+/// Durable progress through the spawn launch flow (spec section 4).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerLaunchCheckpoint {
+    Pending,
+    ResourcesReady,
+    #[default]
+    BriefSubmitted,
 }
 
 /// The Herdr runtime selected when this run was created or adopted.


### PR DESCRIPTION
## Summary
- persist per-worker launch checkpoints and resume pending workers with resource repair
- launch and brief workers concurrently while serializing atomic run-board writes
- fetch optional agent identity lazily after brief submission
- document resume and parallel spawn semantics

## Verification
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test (133 passed)

Closes #14. Closes #17.