### PR TITLE
feat: team wait + god CLI ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ of polling.
   run, delivers with a single verified `pane run`, and — for agents that can't
   safely receive mid-turn — queues to a per-target **outbox** that the status
   hook drains the moment the target goes idle. Sender never blocks, no daemon.
+- **God CLI** — `wait` observes durable lifecycle/report truth with bounded
+  timeouts; `inbox` and `report` track unread worker reports; `msg all` and
+  comma-separated targets reuse the same delivery/outbox policy.
 - **Star or mesh topology** — per-team flag. Star (default): workers report only
   to the god. Mesh: workers also get a peer table and message each other through
   the same `msg` verb with a structured envelope.
@@ -84,6 +87,16 @@ Local development:
 cargo build --release
 herdr plugin link .
 ```
+
+For direct terminal use, put the linked or installed binary on `PATH` once:
+
+```bash
+mkdir -p ~/.local/bin
+ln -sf /path/to/herdr-agent-team/target/release/herdr-agent-team ~/.local/bin/herdr-agent-team
+```
+
+Without Herdr-injected environment variables, the binary resolves the stable
+plugin state/config directories from the standard XDG or home layout.
 
 ## Documentation map
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -422,6 +422,9 @@ herdr-agent-team msg <target> <text> [--attention] [--run <run-dir>]
 - `<target>`: `god` or a worker name from the active run. Resolution: name →
   pane id via `run.toml`. Ambiguity or unknown name = hard error listing
   candidates (never guess — marketplace pattern #2).
+- God-side fan-out accepts `all` or a comma-separated worker list. Every
+  distinct worker uses the same readiness gate and outbox discipline.
+  `--attention` remains valid only for the singular `god` target.
 - Delivery: one `herdr pane run <pane_id> <text>`; submission verified per
   launcher policy (`herdr agent wait --status working`, one empty `pane run`
   retry on timeout — ADR-0006 discipline).
@@ -508,3 +511,31 @@ herdr-agent-team adopt <pane-id> --name <worker> [--role <text>]
 - **Kill semantics:** `team kill` closes only plugin-created workspaces.
   Adopted workers are marked `released` in `run.toml` and receive one
   injected release notice; their panes and workspaces survive.
+
+## 13. God CLI ergonomics — durable wait and inbox (issues #23, #24)
+
+These verbs read the run-board and inbox files only. They never infer
+completion from Herdr pane attention/done presentation, avoiding the
+done-versus-idle trap and upstream #1439's closed-pane subscription hang.
+
+```
+herdr-agent-team wait [--run <dir>] --until any-report|report:<worker>|all-reports|blocked|attention|all-terminal [--timeout <seconds>] [--json]
+herdr-agent-team inbox [--run <dir>] [--unread] [--json]
+herdr-agent-team report <worker> [--run <dir>] [--head N]
+```
+
+- `wait` polls through `GodCollector`, a small snapshot seam intended for the
+  future socket backend. Default timeout is 300 seconds and is always bounded.
+  Reached exits 0, timeout exits 2, and an orphaned/failed required worker
+  without its report exits 3. `--json` emits one stable single-line verdict.
+- Report-file existence is completion truth. `blocked` and `attention` come
+  from durable hook metadata; `all-terminal` comes from worker lifecycle.
+- `inbox` emits one worker row with report presence/mtime, attention, read
+  state, and `STOPPED-NOT-DONE` when an idle/done pointer state has no report.
+  `--unread` retains missing reports and reports newer than their read mark.
+- `report` prints the absolute report path, or at most `N` lines with
+  `--head`, then transactionally persists the report mtime as its read mark in
+  `run.toml` so the mark survives process and agent-context restarts.
+- When `HERDR_PLUGIN_STATE_DIR` / `HERDR_PLUGIN_CONFIG_DIR` are absent, the
+  executable derives Herdr's stable XDG/home plugin layout using its manifest
+  id `caioniehues.agent-team`. Explicit environment always wins.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -527,15 +527,25 @@ herdr-agent-team report <worker> [--run <dir>] [--head N]
 - `wait` polls through `GodCollector`, a small snapshot seam intended for the
   future socket backend. Default timeout is 300 seconds and is always bounded.
   Reached exits 0, timeout exits 2, and an orphaned/failed required worker
-  without its report exits 3. `--json` emits one stable single-line verdict.
+  without its report exits 3. A run that becomes inactive during the wait
+  returns the distinct `inactive_run` verdict and exits 4; an explicitly
+  selected inactive run is rejected before polling. Usage, resolution, and I/O
+  errors exit 1. `--json` emits one stable single-line verdict.
 - Report-file existence is completion truth. `blocked` and `attention` come
   from durable hook metadata; `all-terminal` comes from worker lifecycle.
+  `all-terminal` is literal: failed and orphaned workers count as terminal and
+  the condition exits 0. For `blocked`/`attention`, an all-terminal team that
+  cannot satisfy the condition returns the dead-worker verdict instead.
 - `inbox` emits one worker row with report presence/mtime, attention, read
   state, and `STOPPED-NOT-DONE` when an idle/done pointer state has no report.
   `--unread` retains missing reports and reports newer than their read mark.
 - `report` prints the absolute report path, or at most `N` lines with
   `--head`, then transactionally persists the report mtime as its read mark in
   `run.toml` so the mark survives process and agent-context restarts.
+  Printing the durable path is an intentional pointer handoff and counts as
+  read even when `--head` is omitted.
 - When `HERDR_PLUGIN_STATE_DIR` / `HERDR_PLUGIN_CONFIG_DIR` are absent, the
   executable derives Herdr's stable XDG/home plugin layout using its manifest
   id `caioniehues.agent-team`. Explicit environment always wins.
+  This fallback targets release Herdr's `herdr/` app directory; debug Herdr's
+  `herdr-dev/` layout requires explicit injected environment.

--- a/src/god_cli.rs
+++ b/src/god_cli.rs
@@ -27,6 +27,10 @@ pub enum GodCliError {
     NoActiveRun(PathBuf),
     #[error("unknown worker `{0}`")]
     UnknownWorker(String),
+    #[error("unknown worker `{worker}`; candidates: {candidates}")]
+    UnknownWaitWorker { worker: String, candidates: String },
+    #[error("run is not active: {0}")]
+    InactiveRun(PathBuf),
     #[error("report is not present for worker `{0}`")]
     MissingReport(String),
     #[error("report I/O failed: {0}")]
@@ -84,6 +88,7 @@ pub enum Until {
 pub enum VerdictKind {
     Reached,
     DeadWorker,
+    InactiveRun,
     Timeout,
 }
 
@@ -102,6 +107,7 @@ impl WaitVerdict {
             VerdictKind::Reached => 0,
             VerdictKind::Timeout => 2,
             VerdictKind::DeadWorker => 3,
+            VerdictKind::InactiveRun => 4,
         }
     }
 }
@@ -170,9 +176,9 @@ pub fn report_command(args: &[String]) -> Result<(), GodCliError> {
 
 pub fn wait_command(args: &[String]) -> Result<WaitVerdict, GodCliError> {
     let (run_dir, until, timeout, json) = parse_wait(args)?;
-    let collector = RunGodCollector {
-        run_dir: select_run(run_dir.as_deref())?,
-    };
+    let run_dir = select_wait_run(run_dir.as_deref())?;
+    let collector = RunGodCollector { run_dir };
+    validate_until(&collector.collect()?, &until)?;
     let verdict = wait_with(&collector, &until, timeout)?;
     if json {
         println!("{}", serde_json::to_string(&verdict)?);
@@ -190,6 +196,9 @@ pub fn wait_with(
     let start = Instant::now();
     loop {
         let snapshot = collector.collect()?;
+        if snapshot.lifecycle != RunLifecycle::Active {
+            return Ok(verdict(VerdictKind::InactiveRun, until, None, start));
+        }
         if let Some(worker) = dead_worker(&snapshot, until) {
             return Ok(verdict(VerdictKind::DeadWorker, until, Some(worker), start));
         }
@@ -235,15 +244,42 @@ fn dead_worker(s: &GodSnapshot, until: &Until) -> Option<String> {
     let required = |name: &str| match until {
         Until::Report(w) => w == name,
         Until::AnyReport => !s.rows.iter().any(|r| r.report_present),
-        Until::AllReports | Until::AllTerminal => true,
-        _ => false,
+        Until::AllReports => true,
+        Until::Blocked | Until::Attention => all_terminal_without_reports(s),
+        Until::AllTerminal => false,
     };
     s.worker_lifecycles.iter().find_map(|(name, state)| {
-        (required(name)
-            && matches!(state, WorkerLifecycle::Failed | WorkerLifecycle::Orphaned)
-            && !s.rows.iter().any(|r| r.worker == *name && r.report_present))
-        .then(|| name.clone())
+        let dead = matches!(state, WorkerLifecycle::Failed | WorkerLifecycle::Orphaned)
+            || (matches!(until, Until::Blocked | Until::Attention) && terminal(*state));
+        (required(name) && dead && !s.rows.iter().any(|r| r.worker == *name && r.report_present))
+            .then(|| name.clone())
     })
+}
+
+fn all_terminal_without_reports(snapshot: &GodSnapshot) -> bool {
+    !snapshot.worker_lifecycles.is_empty()
+        && snapshot
+            .worker_lifecycles
+            .iter()
+            .all(|(_, lifecycle)| terminal(*lifecycle))
+        && snapshot.rows.iter().all(|row| !row.report_present)
+}
+
+fn validate_until(snapshot: &GodSnapshot, until: &Until) -> Result<(), GodCliError> {
+    if let Until::Report(worker) = until {
+        if !snapshot.rows.iter().any(|row| row.worker == *worker) {
+            return Err(GodCliError::UnknownWaitWorker {
+                worker: worker.clone(),
+                candidates: snapshot
+                    .rows
+                    .iter()
+                    .map(|row| row.worker.clone())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            });
+        }
+    }
+    Ok(())
 }
 
 fn terminal(state: WorkerLifecycle) -> bool {
@@ -319,6 +355,14 @@ fn select_run(explicit: Option<&Path>) -> Result<PathBuf, GodCliError> {
         .pop()
         .map(|r| r.dir)
         .ok_or(GodCliError::NoActiveRun(state))
+}
+
+fn select_wait_run(explicit: Option<&Path>) -> Result<PathBuf, GodCliError> {
+    let path = select_run(explicit)?;
+    if load_run(&path)?.state.lifecycle != RunLifecycle::Active {
+        return Err(GodCliError::InactiveRun(path));
+    }
+    Ok(path)
 }
 
 fn parse_inbox(args: &[String]) -> Result<(Option<PathBuf>, bool, bool), GodCliError> {
@@ -543,6 +587,28 @@ mod tests {
                 .exit_code(),
             2
         );
+    }
+
+    #[test]
+    fn inactive_run_unknown_report_and_terminal_conditions_are_distinct() {
+        let mut inactive = snap(false, "working", WorkerLifecycle::Running);
+        inactive.lifecycle = RunLifecycle::Ended;
+        let fake = Fake {
+            snapshots: std::sync::Mutex::new(vec![inactive]),
+        };
+        let verdict = wait_with(&fake, &Until::AnyReport, Duration::from_secs(1)).unwrap();
+        assert_eq!(verdict.verdict, VerdictKind::InactiveRun);
+        assert_eq!(verdict.exit_code(), 4);
+
+        let running = snap(false, "working", WorkerLifecycle::Running);
+        let error = validate_until(&running, &Until::Report("missing".into())).unwrap_err();
+        assert!(error.to_string().contains("candidates: a"));
+
+        let terminal = snap(false, "done", WorkerLifecycle::Orphaned);
+        assert!(condition_met(&terminal, &Until::AllTerminal));
+        assert_eq!(dead_worker(&terminal, &Until::AllTerminal), None);
+        assert_eq!(dead_worker(&terminal, &Until::Blocked), Some("a".into()));
+        assert_eq!(dead_worker(&terminal, &Until::Attention), Some("a".into()));
     }
 
     #[test]

--- a/src/god_cli.rs
+++ b/src/god_cli.rs
@@ -1,0 +1,612 @@
+//! Durable god-side inbox, report, and wait verbs (spec section 13).
+
+use crate::paths;
+use crate::reconcile::HookMetadata;
+use crate::run::{list_active_runs, load_hook_metadata, load_run, update_run_with_hook, RunError};
+use crate::types::{RunLifecycle, WorkerLifecycle};
+use serde::Serialize;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant, UNIX_EPOCH};
+use thiserror::Error;
+
+const DEFAULT_TIMEOUT_SECS: u64 = 300;
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+#[derive(Debug, Error)]
+pub enum GodCliError {
+    #[error("invalid arguments: {0}")]
+    Usage(String),
+    #[error(transparent)]
+    Run(#[from] RunError),
+    #[error(transparent)]
+    Paths(#[from] paths::PathError),
+    #[error("no active team run found under {0}")]
+    NoActiveRun(PathBuf),
+    #[error("unknown worker `{0}`")]
+    UnknownWorker(String),
+    #[error("report is not present for worker `{0}`")]
+    MissingReport(String),
+    #[error("report I/O failed: {0}")]
+    Io(#[from] io::Error),
+    #[error("cannot serialize JSON verdict: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InboxRow {
+    pub worker: String,
+    pub report_present: bool,
+    pub report_mtime_ms: Option<u64>,
+    pub attention: bool,
+    pub read: bool,
+    pub stopped_not_done: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GodSnapshot {
+    pub run_dir: PathBuf,
+    pub lifecycle: RunLifecycle,
+    pub rows: Vec<InboxRow>,
+    pub worker_lifecycles: Vec<(String, WorkerLifecycle)>,
+    pub statuses: Vec<(String, String)>,
+}
+
+/// Polling seam intentionally mirrors `BoardCollector`; #8 can replace it.
+pub trait GodCollector {
+    fn collect(&self) -> Result<GodSnapshot, GodCliError>;
+}
+
+pub struct RunGodCollector {
+    pub run_dir: PathBuf,
+}
+
+impl GodCollector for RunGodCollector {
+    fn collect(&self) -> Result<GodSnapshot, GodCliError> {
+        collect_snapshot(&self.run_dir)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Until {
+    AnyReport,
+    Report(String),
+    AllReports,
+    Blocked,
+    Attention,
+    AllTerminal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerdictKind {
+    Reached,
+    DeadWorker,
+    Timeout,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WaitVerdict {
+    pub verdict: VerdictKind,
+    pub until: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worker: Option<String>,
+    pub elapsed_ms: u64,
+}
+
+impl WaitVerdict {
+    pub fn exit_code(&self) -> u8 {
+        match self.verdict {
+            VerdictKind::Reached => 0,
+            VerdictKind::Timeout => 2,
+            VerdictKind::DeadWorker => 3,
+        }
+    }
+}
+
+pub fn inbox_command(args: &[String]) -> Result<(), GodCliError> {
+    let (run_dir, unread, json) = parse_inbox(args)?;
+    let rows = collect_snapshot(&select_run(run_dir.as_deref())?)?.rows;
+    let rows = rows
+        .into_iter()
+        .filter(|row| !unread || !row.read)
+        .collect::<Vec<_>>();
+    if json {
+        println!("{}", serde_json::to_string(&rows)?);
+    } else {
+        for row in rows {
+            let state = if row.stopped_not_done {
+                "STOPPED-NOT-DONE"
+            } else if row.report_present {
+                "REPORT"
+            } else {
+                "-"
+            };
+            println!(
+                "{}\t{}\tattention={}\tread={}\tmtime={}",
+                row.worker,
+                state,
+                row.attention,
+                row.read,
+                row.report_mtime_ms
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "-".into())
+            );
+        }
+    }
+    Ok(())
+}
+
+pub fn report_command(args: &[String]) -> Result<(), GodCliError> {
+    let (worker, run_dir, head) = parse_report(args)?;
+    let run_dir = select_run(run_dir.as_deref())?;
+    let run = load_run(&run_dir)?;
+    if !run.state.workers.contains_key(&worker) {
+        return Err(GodCliError::UnknownWorker(worker));
+    }
+    let path = run_dir.join("inbox").join(format!("{worker}.md"));
+    if !path.is_file() {
+        return Err(GodCliError::MissingReport(worker));
+    }
+    let mtime = report_mtime_ms(&path)?.unwrap_or(0);
+    update_run_with_hook::<_, GodCliError>(&run_dir, |_, hook| {
+        hook.report_read_mtime_ms.insert(worker.clone(), mtime);
+        Ok(())
+    })?;
+    match head {
+        None => println!("{}", path.display()),
+        Some(lines) => {
+            let contents = fs::read_to_string(path)?;
+            let mut stdout = io::stdout().lock();
+            for line in contents.lines().take(lines) {
+                writeln!(stdout, "{line}")?;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn wait_command(args: &[String]) -> Result<WaitVerdict, GodCliError> {
+    let (run_dir, until, timeout, json) = parse_wait(args)?;
+    let collector = RunGodCollector {
+        run_dir: select_run(run_dir.as_deref())?,
+    };
+    let verdict = wait_with(&collector, &until, timeout)?;
+    if json {
+        println!("{}", serde_json::to_string(&verdict)?);
+    } else {
+        println!("{:?}: {}", verdict.verdict, verdict.until);
+    }
+    Ok(verdict)
+}
+
+pub fn wait_with(
+    collector: &impl GodCollector,
+    until: &Until,
+    timeout: Duration,
+) -> Result<WaitVerdict, GodCliError> {
+    let start = Instant::now();
+    loop {
+        let snapshot = collector.collect()?;
+        if let Some(worker) = dead_worker(&snapshot, until) {
+            return Ok(verdict(VerdictKind::DeadWorker, until, Some(worker), start));
+        }
+        if condition_met(&snapshot, until) {
+            return Ok(verdict(VerdictKind::Reached, until, None, start));
+        }
+        if start.elapsed() >= timeout {
+            return Ok(verdict(VerdictKind::Timeout, until, None, start));
+        }
+        thread::sleep(POLL_INTERVAL.min(timeout.saturating_sub(start.elapsed())));
+    }
+}
+
+fn verdict(
+    kind: VerdictKind,
+    until: &Until,
+    worker: Option<String>,
+    start: Instant,
+) -> WaitVerdict {
+    WaitVerdict {
+        verdict: kind,
+        until: until_name(until),
+        worker,
+        elapsed_ms: start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+    }
+}
+
+fn condition_met(s: &GodSnapshot, until: &Until) -> bool {
+    match until {
+        Until::AnyReport => s.rows.iter().any(|r| r.report_present),
+        Until::Report(name) => s.rows.iter().any(|r| r.worker == *name && r.report_present),
+        Until::AllReports => !s.rows.is_empty() && s.rows.iter().all(|r| r.report_present),
+        Until::Blocked => s.statuses.iter().any(|(_, status)| status == "blocked"),
+        Until::Attention => s.rows.iter().any(|r| r.attention),
+        Until::AllTerminal => s
+            .worker_lifecycles
+            .iter()
+            .all(|(_, state)| terminal(*state)),
+    }
+}
+
+fn dead_worker(s: &GodSnapshot, until: &Until) -> Option<String> {
+    let required = |name: &str| match until {
+        Until::Report(w) => w == name,
+        Until::AnyReport => !s.rows.iter().any(|r| r.report_present),
+        Until::AllReports | Until::AllTerminal => true,
+        _ => false,
+    };
+    s.worker_lifecycles.iter().find_map(|(name, state)| {
+        (required(name)
+            && matches!(state, WorkerLifecycle::Failed | WorkerLifecycle::Orphaned)
+            && !s.rows.iter().any(|r| r.worker == *name && r.report_present))
+        .then(|| name.clone())
+    })
+}
+
+fn terminal(state: WorkerLifecycle) -> bool {
+    matches!(
+        state,
+        WorkerLifecycle::Failed
+            | WorkerLifecycle::Ended
+            | WorkerLifecycle::Released
+            | WorkerLifecycle::Orphaned
+    )
+}
+
+fn collect_snapshot(run_dir: &Path) -> Result<GodSnapshot, GodCliError> {
+    let run = load_run(run_dir)?;
+    let hook = load_hook_metadata(run_dir)?;
+    let rows = run
+        .state
+        .spec
+        .workers
+        .iter()
+        .map(|worker| row(run_dir, &hook, &worker.name))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(GodSnapshot {
+        run_dir: run_dir.to_path_buf(),
+        lifecycle: run.state.lifecycle,
+        rows,
+        worker_lifecycles: run
+            .state
+            .workers
+            .iter()
+            .map(|(n, w)| (n.clone(), w.lifecycle))
+            .collect(),
+        statuses: hook.worker_status.into_iter().collect(),
+    })
+}
+
+fn row(run_dir: &Path, hook: &HookMetadata, worker: &str) -> Result<InboxRow, GodCliError> {
+    let path = run_dir.join("inbox").join(format!("{worker}.md"));
+    let mtime = report_mtime_ms(&path)?;
+    let status = hook.worker_status.get(worker).map(String::as_str);
+    Ok(InboxRow {
+        worker: worker.into(),
+        report_present: mtime.is_some(),
+        report_mtime_ms: mtime,
+        attention: hook.attention_pending.get(worker).copied().unwrap_or(false)
+            || status == Some("blocked"),
+        read: mtime
+            .is_some_and(|m| hook.report_read_mtime_ms.get(worker).copied().unwrap_or(0) >= m),
+        stopped_not_done: mtime.is_none() && matches!(status, Some("idle" | "done")),
+    })
+}
+
+fn report_mtime_ms(path: &Path) -> Result<Option<u64>, io::Error> {
+    match fs::metadata(path) {
+        Ok(meta) => Ok(Some(
+            meta.modified()?
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+                .min(u128::from(u64::MAX)) as u64,
+        )),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+fn select_run(explicit: Option<&Path>) -> Result<PathBuf, GodCliError> {
+    if let Some(path) = explicit {
+        return Ok(path.to_path_buf());
+    }
+    let state = paths::state_dir()?;
+    list_active_runs(&state)?
+        .pop()
+        .map(|r| r.dir)
+        .ok_or(GodCliError::NoActiveRun(state))
+}
+
+fn parse_inbox(args: &[String]) -> Result<(Option<PathBuf>, bool, bool), GodCliError> {
+    let mut run = None;
+    let mut unread = false;
+    let mut json = false;
+    parse_flags(args, |flag, value| match flag {
+        "--run" => {
+            run =
+                Some(PathBuf::from(value.ok_or_else(|| {
+                    usage("inbox [--run <dir>] [--unread] [--json]")
+                })?));
+            Ok(true)
+        }
+        "--unread" => {
+            unread = true;
+            Ok(false)
+        }
+        "--json" => {
+            json = true;
+            Ok(false)
+        }
+        _ => Err(usage("inbox [--run <dir>] [--unread] [--json]")),
+    })?;
+    Ok((run, unread, json))
+}
+fn parse_report(args: &[String]) -> Result<(String, Option<PathBuf>, Option<usize>), GodCliError> {
+    let worker = args
+        .first()
+        .filter(|s| !s.starts_with('-'))
+        .cloned()
+        .ok_or_else(|| usage("report <worker> [--run <dir>] [--head N]"))?;
+    let mut run = None;
+    let mut head = None;
+    parse_flags(&args[1..], |f, v| match f {
+        "--run" => {
+            run = Some(PathBuf::from(v.ok_or_else(|| {
+                usage("report <worker> [--run <dir>] [--head N]")
+            })?));
+            Ok(true)
+        }
+        "--head" => {
+            head = Some(
+                v.ok_or_else(|| usage("--head requires N"))?
+                    .parse()
+                    .map_err(|_| usage("--head requires an integer"))?,
+            );
+            Ok(true)
+        }
+        _ => Err(usage("report <worker> [--run <dir>] [--head N]")),
+    })?;
+    Ok((worker, run, head))
+}
+fn parse_wait(args: &[String]) -> Result<(Option<PathBuf>, Until, Duration, bool), GodCliError> {
+    let mut run = None;
+    let mut until = None;
+    let mut timeout = DEFAULT_TIMEOUT_SECS;
+    let mut json = false;
+    parse_flags(args, |f, v| match f {
+        "--run" => {
+            run = Some(PathBuf::from(v.ok_or_else(|| {
+                usage("wait --until <condition> [--run <dir>] [--timeout <s>] [--json]")
+            })?));
+            Ok(true)
+        }
+        "--until" => {
+            until = Some(parse_until(
+                v.ok_or_else(|| usage("--until requires a condition"))?,
+            )?);
+            Ok(true)
+        }
+        "--timeout" => {
+            timeout = v
+                .ok_or_else(|| usage("--timeout requires seconds"))?
+                .parse()
+                .map_err(|_| usage("--timeout requires integer seconds"))?;
+            Ok(true)
+        }
+        "--json" => {
+            json = true;
+            Ok(false)
+        }
+        _ => Err(usage(
+            "wait --until <condition> [--run <dir>] [--timeout <s>] [--json]",
+        )),
+    })?;
+    Ok((
+        run,
+        until.ok_or_else(|| usage("--until is required"))?,
+        Duration::from_secs(timeout),
+        json,
+    ))
+}
+fn parse_flags<F>(args: &[String], mut f: F) -> Result<(), GodCliError>
+where
+    F: FnMut(&str, Option<&str>) -> Result<bool, GodCliError>,
+{
+    let mut i = 0;
+    while i < args.len() {
+        let consumed = f(&args[i], args.get(i + 1).map(String::as_str))?;
+        i += if consumed { 2 } else { 1 };
+    }
+    Ok(())
+}
+fn parse_until(v: &str) -> Result<Until, GodCliError> {
+    Ok(match v {
+        "any-report" => Until::AnyReport,
+        "all-reports" => Until::AllReports,
+        "blocked" => Until::Blocked,
+        "attention" => Until::Attention,
+        "all-terminal" => Until::AllTerminal,
+        _ if v.starts_with("report:") && v.len() > 7 => Until::Report(v[7..].into()),
+        _ => return Err(usage("unknown --until condition")),
+    })
+}
+fn until_name(v: &Until) -> String {
+    match v {
+        Until::AnyReport => "any-report".into(),
+        Until::Report(w) => format!("report:{w}"),
+        Until::AllReports => "all-reports".into(),
+        Until::Blocked => "blocked".into(),
+        Until::Attention => "attention".into(),
+        Until::AllTerminal => "all-terminal".into(),
+    }
+}
+fn usage(s: &str) -> GodCliError {
+    GodCliError::Usage(s.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{GodSpec, RunState, TeamSpec, Topology, WorkerRunState, WorkerSpec};
+    use std::collections::BTreeMap;
+    struct Fake {
+        snapshots: std::sync::Mutex<Vec<GodSnapshot>>,
+    }
+    impl GodCollector for Fake {
+        fn collect(&self) -> Result<GodSnapshot, GodCliError> {
+            let mut v = self.snapshots.lock().unwrap();
+            Ok(if v.len() > 1 {
+                v.remove(0)
+            } else {
+                v[0].clone()
+            })
+        }
+    }
+    fn snap(report: bool, status: &str, life: WorkerLifecycle) -> GodSnapshot {
+        GodSnapshot {
+            run_dir: "/run".into(),
+            lifecycle: RunLifecycle::Active,
+            rows: vec![InboxRow {
+                worker: "a".into(),
+                report_present: report,
+                report_mtime_ms: report.then_some(1),
+                attention: status == "attention",
+                read: false,
+                stopped_not_done: false,
+            }],
+            worker_lifecycles: vec![("a".into(), life)],
+            statuses: vec![("a".into(), status.into())],
+        }
+    }
+    #[test]
+    fn every_until_mode_resolves() {
+        for (until, s) in [
+            (
+                Until::AnyReport,
+                snap(true, "working", WorkerLifecycle::Running),
+            ),
+            (
+                Until::Report("a".into()),
+                snap(true, "working", WorkerLifecycle::Running),
+            ),
+            (
+                Until::AllReports,
+                snap(true, "working", WorkerLifecycle::Running),
+            ),
+            (
+                Until::Blocked,
+                snap(false, "blocked", WorkerLifecycle::Running),
+            ),
+            (
+                Until::Attention,
+                snap(false, "attention", WorkerLifecycle::Running),
+            ),
+            (
+                Until::AllTerminal,
+                snap(false, "done", WorkerLifecycle::Ended),
+            ),
+        ] {
+            let f = Fake {
+                snapshots: std::sync::Mutex::new(vec![s]),
+            };
+            assert_eq!(
+                wait_with(&f, &until, Duration::ZERO).unwrap().verdict,
+                VerdictKind::Reached
+            );
+        }
+    }
+    #[test]
+    fn dead_and_timeout_are_distinct_and_json_is_stable() {
+        let dead = Fake {
+            snapshots: std::sync::Mutex::new(vec![snap(false, "done", WorkerLifecycle::Orphaned)]),
+        };
+        let d = wait_with(&dead, &Until::AllReports, Duration::ZERO).unwrap();
+        assert_eq!(d.exit_code(), 3);
+        assert_eq!(
+            serde_json::to_string(&d).unwrap(),
+            r#"{"verdict":"dead_worker","until":"all-reports","worker":"a","elapsed_ms":0}"#
+        );
+        let live = Fake {
+            snapshots: std::sync::Mutex::new(vec![snap(
+                false,
+                "working",
+                WorkerLifecycle::Running,
+            )]),
+        };
+        assert_eq!(
+            wait_with(&live, &Until::AnyReport, Duration::ZERO)
+                .unwrap()
+                .exit_code(),
+            2
+        );
+    }
+
+    #[test]
+    fn inbox_detects_stopped_not_done_and_read_marks_persist() {
+        let root = std::env::temp_dir().join(format!("god-cli-inbox-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let worker = WorkerSpec {
+            name: "a".into(),
+            agent: "codex".into(),
+            role: "builder".into(),
+            task: None,
+            worktree: false,
+            branch: None,
+            brief: "brief.md".into(),
+        };
+        let state = RunState {
+            spec: TeamSpec {
+                name: "team".into(),
+                topology: Topology::Star,
+                cwd: ".".into(),
+                setup: vec![],
+                god: GodSpec::default(),
+                workers: vec![worker],
+            },
+            god_pane_id: "god".into(),
+            herdr_session: Default::default(),
+            workers: BTreeMap::from([(
+                "a".into(),
+                WorkerRunState {
+                    task: None,
+                    workspace_id: None,
+                    pane_id: Some("pane".into()),
+                    agent_id: None,
+                    agent_session: None,
+                    worktree_path: None,
+                    adopted: false,
+                    launch_checkpoint: Default::default(),
+                    lifecycle: WorkerLifecycle::Running,
+                },
+            )]),
+            lifecycle: RunLifecycle::Active,
+        };
+        let run = crate::run::create_run(&root, state).unwrap();
+        let mut hook = load_hook_metadata(&run.dir).unwrap();
+        hook.worker_status.insert("a".into(), "done".into());
+        crate::run::save_run_with_hook(&run, &hook).unwrap();
+        assert!(collect_snapshot(&run.dir).unwrap().rows[0].stopped_not_done);
+
+        let report = run.dir.join("inbox/a.md");
+        fs::write(&report, "one\ntwo\n").unwrap();
+        let mtime = report_mtime_ms(&report).unwrap().unwrap();
+        update_run_with_hook::<_, GodCliError>(&run.dir, |_, hook| {
+            hook.report_read_mtime_ms.insert("a".into(), mtime);
+            Ok(())
+        })
+        .unwrap();
+        let row = collect_snapshot(&run.dir).unwrap().rows.remove(0);
+        assert!(row.read);
+        assert!(!row.stopped_not_done);
+        assert_eq!(
+            load_hook_metadata(&run.dir).unwrap().report_read_mtime_ms["a"],
+            mtime
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,11 +9,13 @@ use std::process::ExitCode;
 pub mod adopt;
 pub mod agents_md;
 pub mod board;
+pub mod god_cli;
 pub mod herdr;
 pub mod hook;
 pub mod launcher;
 pub mod metadata;
 pub mod msg;
+pub mod paths;
 pub mod reconcile;
 pub mod run;
 pub mod spawn;
@@ -22,6 +24,7 @@ pub mod status_kill;
 pub mod types;
 
 fn main() -> ExitCode {
+    paths::hydrate_environment();
     let mut args = std::env::args().skip(1);
     let command = args.next().unwrap_or_default();
     let args = args.collect::<Vec<_>>();
@@ -33,11 +36,20 @@ fn main() -> ExitCode {
         "spawn" => exit(spawn::spawn_command(&args)),
         "status" => exit(status_kill::status_command(&args)),
         "kill" => exit(status_kill::kill_command(&args)),
+        "inbox" => exit(god_cli::inbox_command(&args)),
+        "report" => exit(god_cli::report_command(&args)),
+        "wait" => match god_cli::wait_command(&args) {
+            Ok(verdict) => ExitCode::from(verdict.exit_code()),
+            Err(error) => {
+                eprintln!("{error}");
+                ExitCode::FAILURE
+            }
+        },
         "msg" => exit(msg::msg_command(&args)),
         "on-agent-status" => exit(hook::hook_command()),
         "" | "help" | "--help" | "-h" => {
             eprintln!(
-                "herdr-agent-team <adopt|board|spawn|status|kill|msg|open-report|on-agent-status>"
+                "herdr-agent-team <adopt|board|spawn|status|kill|inbox|report|wait|msg|open-report|on-agent-status>"
             );
             ExitCode::SUCCESS
         }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -79,6 +79,9 @@ pub enum MsgError {
     #[error("--attention is only valid for a worker message to god")]
     AttentionTarget,
 
+    #[error("message fan-out failed: {0}")]
+    Fanout(String),
+
     #[error("--attention requires HERDR_PANE_ID for a recorded worker pane")]
     AttentionSource,
 }
@@ -112,16 +115,18 @@ enum MessageOutcome {
 }
 
 pub fn msg_command(args: &[String]) -> Result<(), MsgError> {
-    let arguments = parse_msg_arguments(args)?;
-    if arguments.attention && arguments.target != "god" {
-        return Err(MsgError::AttentionTarget);
+    let parsed = parse_msg_arguments(args)?;
+    if parsed.attention && parsed.target != "god" {
+        return Err(arguments(
+            "--attention is only valid with the singular god target",
+        ));
     }
-    let run = select_run(arguments.run_dir.as_deref())?;
+    let run = select_run(parsed.run_dir.as_deref())?;
     let launchers = load_launchers()?;
     let herdr = HerdrClient::from_env();
-    send_to_targets(&run, &launchers, &arguments.target, &arguments.text, &herdr)?;
-    if arguments.attention {
-        request_attention(&run, &arguments.target, &arguments.text, &herdr)?;
+    send_to_targets(&run, &launchers, &parsed.target, &parsed.text, &herdr)?;
+    if parsed.attention {
+        request_attention(&run, &parsed.target, &parsed.text, &herdr)?;
     }
     Ok(())
 }
@@ -134,7 +139,12 @@ fn send_to_targets<H: HerdrApi>(
     herdr: &H,
 ) -> Result<(), MsgError> {
     let names = if target == "all" {
-        run.state.workers.keys().cloned().collect::<Vec<_>>()
+        run.state
+            .workers
+            .iter()
+            .filter(|(_, worker)| !terminal_lifecycle(worker.lifecycle))
+            .map(|(name, _)| name.clone())
+            .collect::<Vec<_>>()
     } else if target.contains(',') {
         let names = target
             .split(',')
@@ -150,13 +160,38 @@ fn send_to_targets<H: HerdrApi>(
         vec![target.to_owned()]
     };
     let mut seen = BTreeSet::new();
-    for name in names {
-        if !seen.insert(name.clone()) {
-            continue;
-        }
-        send_message(run, launchers, &name, text, herdr)?;
+    let names = names
+        .into_iter()
+        .filter(|name| seen.insert(name.clone()))
+        .collect::<Vec<_>>();
+
+    // Resolve the complete set before the first side effect.
+    for name in &names {
+        resolve_target(run, name)?;
+    }
+
+    let errors = names
+        .iter()
+        .filter_map(|name| {
+            send_message(run, launchers, name, text, herdr)
+                .err()
+                .map(|error| format!("{name}: {error}"))
+        })
+        .collect::<Vec<_>>();
+    if !errors.is_empty() {
+        return Err(MsgError::Fanout(errors.join("; ")));
     }
     Ok(())
+}
+
+fn terminal_lifecycle(lifecycle: crate::types::WorkerLifecycle) -> bool {
+    matches!(
+        lifecycle,
+        crate::types::WorkerLifecycle::Failed
+            | crate::types::WorkerLifecycle::Ended
+            | crate::types::WorkerLifecycle::Released
+            | crate::types::WorkerLifecycle::Orphaned
+    )
 }
 
 pub(crate) fn deliver_queued_message<H: HerdrApi>(
@@ -805,6 +840,62 @@ mod tests {
             fs::read_to_string(temp.path().join("outbox/b/00000000000000000002.msg")).unwrap(),
             "subset"
         );
+    }
+
+    #[test]
+    fn fanout_prevalidates_filters_terminal_and_collects_delivery_errors() {
+        let temp = TempDir::new();
+        let mut run = fixture_run(temp.path(), "a", "codex");
+        let spec = run.state.spec.workers[0].clone();
+        for (name, pane) in [("b", "worker-pane-b"), ("dead", "worker-pane-dead")] {
+            run.state.spec.workers.push(WorkerSpec {
+                name: name.into(),
+                ..spec.clone()
+            });
+            let mut state = run.state.workers["a"].clone();
+            state.pane_id = Some(pane.into());
+            if name == "dead" {
+                state.lifecycle = WorkerLifecycle::Orphaned;
+            }
+            run.state.workers.insert(name.into(), state);
+        }
+
+        let prevalidate = fake_herdr("codex", Some("working"), []);
+        let error = send_to_targets(
+            &run,
+            &conservative_table(),
+            "a,missing,b",
+            "text",
+            &prevalidate,
+        )
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("unknown message target `missing`"));
+        assert!(prevalidate.typed_calls().is_empty());
+
+        let filtered = fake_herdr("codex", Some("working"), []);
+        send_to_targets(&run, &conservative_table(), "all", "text", &filtered).unwrap();
+        assert!(!temp.path().join("outbox/dead").exists());
+
+        let failing = fake_herdr("codex", Some("idle"), [WaitOutcome::Reached]);
+        failing
+            .missing_panes
+            .borrow_mut()
+            .insert("worker-pane".into());
+        let error =
+            send_to_targets(&run, &conservative_table(), "a,b", "text", &failing).unwrap_err();
+        assert!(error.to_string().contains("a:"));
+        assert!(failing
+            .typed_calls()
+            .iter()
+            .any(|call| matches!(call, Call::PaneRun(pane, _) if pane == "worker-pane-b")));
+    }
+
+    #[test]
+    fn attention_rejects_non_singular_god_before_run_resolution() {
+        let error = msg_command(&["all".into(), "text".into(), "--attention".into()]).unwrap_err();
+        assert!(matches!(error, MsgError::Arguments(_)));
     }
 
     #[test]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -119,9 +119,42 @@ pub fn msg_command(args: &[String]) -> Result<(), MsgError> {
     let run = select_run(arguments.run_dir.as_deref())?;
     let launchers = load_launchers()?;
     let herdr = HerdrClient::from_env();
-    send_message(&run, &launchers, &arguments.target, &arguments.text, &herdr)?;
+    send_to_targets(&run, &launchers, &arguments.target, &arguments.text, &herdr)?;
     if arguments.attention {
         request_attention(&run, &arguments.target, &arguments.text, &herdr)?;
+    }
+    Ok(())
+}
+
+fn send_to_targets<H: HerdrApi>(
+    run: &RunBoard,
+    launchers: &LauncherTable,
+    target: &str,
+    text: &str,
+    herdr: &H,
+) -> Result<(), MsgError> {
+    let names = if target == "all" {
+        run.state.workers.keys().cloned().collect::<Vec<_>>()
+    } else if target.contains(',') {
+        let names = target
+            .split(',')
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        if names.is_empty() {
+            return Err(arguments("target list is empty"));
+        }
+        names
+    } else {
+        vec![target.to_owned()]
+    };
+    let mut seen = BTreeSet::new();
+    for name in names {
+        if !seen.insert(name.clone()) {
+            continue;
+        }
+        send_message(run, launchers, &name, text, herdr)?;
     }
     Ok(())
 }
@@ -738,6 +771,39 @@ mod tests {
                 Call::PaneGet("worker-pane".to_owned()),
                 Call::PaneGet("worker-pane".to_owned()),
             ]
+        );
+    }
+
+    #[test]
+    fn fanout_all_and_subset_reuse_delivery_and_outbox_discipline() {
+        let temp = TempDir::new();
+        let mut run = fixture_run(temp.path(), "a", "codex");
+        let b = run.state.spec.workers[0].clone();
+        run.state.spec.workers.push(WorkerSpec {
+            name: "b".into(),
+            ..b
+        });
+        let mut bstate = run.state.workers["a"].clone();
+        bstate.pane_id = Some("worker-pane-b".into());
+        run.state.workers.insert("b".into(), bstate);
+        let herdr = fake_herdr("codex", Some("working"), []);
+        send_to_targets(&run, &conservative_table(), "all", "broadcast", &herdr).unwrap();
+        assert_eq!(
+            fs::read_to_string(temp.path().join("outbox/a/00000000000000000001.msg")).unwrap(),
+            "broadcast"
+        );
+        assert_eq!(
+            fs::read_to_string(temp.path().join("outbox/b/00000000000000000001.msg")).unwrap(),
+            "broadcast"
+        );
+        send_to_targets(&run, &conservative_table(), "b,a,b", "subset", &herdr).unwrap();
+        assert_eq!(
+            fs::read_to_string(temp.path().join("outbox/a/00000000000000000002.msg")).unwrap(),
+            "subset"
+        );
+        assert_eq!(
+            fs::read_to_string(temp.path().join("outbox/b/00000000000000000002.msg")).unwrap(),
+            "subset"
         );
     }
 

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -139,12 +139,17 @@ fn send_to_targets<H: HerdrApi>(
     herdr: &H,
 ) -> Result<(), MsgError> {
     let names = if target == "all" {
-        run.state
+        let names = run
+            .state
             .workers
             .iter()
             .filter(|(_, worker)| !terminal_lifecycle(worker.lifecycle))
             .map(|(name, _)| name.clone())
-            .collect::<Vec<_>>()
+            .collect::<Vec<_>>();
+        if names.is_empty() {
+            return Err(arguments("no live workers to message"));
+        }
+        names
     } else if target.contains(',') {
         let names = target
             .split(',')
@@ -896,6 +901,21 @@ mod tests {
     fn attention_rejects_non_singular_god_before_run_resolution() {
         let error = msg_command(&["all".into(), "text".into(), "--attention".into()]).unwrap_err();
         assert!(matches!(error, MsgError::Arguments(_)));
+    }
+
+    #[test]
+    fn fanout_all_rejects_a_run_with_no_live_workers() {
+        let temp = TempDir::new();
+        let mut run = fixture_run(temp.path(), "dead", "codex");
+        run.state.workers.get_mut("dead").unwrap().lifecycle = WorkerLifecycle::Ended;
+        let herdr = fake_herdr("codex", Some("idle"), []);
+
+        let error =
+            send_to_targets(&run, &default_launcher_table(), "all", "text", &herdr).unwrap_err();
+
+        assert!(matches!(error, MsgError::Arguments(_)));
+        assert!(error.to_string().contains("no live workers to message"));
+        assert!(herdr.typed_calls().is_empty());
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,102 @@
+//! Self-resolution of Herdr plugin directories (spec section 13).
+
+use std::env;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+pub const PLUGIN_ID: &str = "caioniehues.agent-team";
+
+#[derive(Debug, Error)]
+pub enum PathError {
+    #[error("cannot resolve {name}: set {name} or HOME (XDG overrides are supported)")]
+    Unresolved { name: &'static str },
+}
+
+pub fn state_dir() -> Result<PathBuf, PathError> {
+    resolve_dir(
+        "HERDR_PLUGIN_STATE_DIR",
+        "XDG_STATE_HOME",
+        ".local/state",
+        Path::new("herdr/plugins").join(PLUGIN_ID),
+    )
+}
+
+pub fn config_dir() -> Result<PathBuf, PathError> {
+    resolve_dir(
+        "HERDR_PLUGIN_CONFIG_DIR",
+        "XDG_CONFIG_HOME",
+        ".config",
+        Path::new("herdr/plugins/config").join(PLUGIN_ID),
+    )
+}
+
+/// Populate the same variables Herdr injects for direct PATH invocation.
+pub fn hydrate_environment() {
+    if env::var_os("HERDR_PLUGIN_STATE_DIR").is_none() {
+        if let Ok(path) = state_dir() {
+            env::set_var("HERDR_PLUGIN_STATE_DIR", path);
+        }
+    }
+    if env::var_os("HERDR_PLUGIN_CONFIG_DIR").is_none() {
+        if let Ok(path) = config_dir() {
+            env::set_var("HERDR_PLUGIN_CONFIG_DIR", path);
+        }
+    }
+}
+
+fn resolve_dir(
+    explicit: &'static str,
+    xdg: &str,
+    home_suffix: &str,
+    herdr_suffix: PathBuf,
+) -> Result<PathBuf, PathError> {
+    if let Some(path) = env::var_os(explicit) {
+        return Ok(PathBuf::from(path));
+    }
+    let base = env::var_os(xdg)
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(home_suffix)))
+        .ok_or(PathError::Unresolved { name: explicit })?;
+    Ok(base.join(herdr_suffix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn explicit_environment_wins_and_well_known_layout_is_fallback() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        env::set_var("HERDR_PLUGIN_STATE_DIR", "/explicit/state");
+        env::set_var("XDG_STATE_HOME", "/xdg/state");
+        assert_eq!(state_dir().unwrap(), PathBuf::from("/explicit/state"));
+        env::remove_var("HERDR_PLUGIN_STATE_DIR");
+        assert_eq!(
+            state_dir().unwrap(),
+            PathBuf::from("/xdg/state/herdr/plugins").join(PLUGIN_ID)
+        );
+        env::remove_var("XDG_STATE_HOME");
+    }
+
+    #[test]
+    fn missing_environment_has_a_clear_error() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved = ["HERDR_PLUGIN_CONFIG_DIR", "XDG_CONFIG_HOME", "HOME"]
+            .map(|key| (key, env::var_os(key)));
+        for (key, _) in &saved {
+            env::remove_var(key);
+        }
+        assert!(config_dir()
+            .unwrap_err()
+            .to_string()
+            .contains("HERDR_PLUGIN_CONFIG_DIR"));
+        for (key, value) in saved {
+            if let Some(value) = value {
+                env::set_var(key, value);
+            }
+        }
+    }
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -50,53 +50,86 @@ fn resolve_dir(
     home_suffix: &str,
     herdr_suffix: PathBuf,
 ) -> Result<PathBuf, PathError> {
-    if let Some(path) = env::var_os(explicit) {
+    resolve_dir_values(
+        explicit,
+        env::var_os(explicit),
+        env::var_os(xdg),
+        env::var_os("HOME"),
+        home_suffix,
+        herdr_suffix,
+    )
+}
+
+fn resolve_dir_values(
+    explicit_name: &'static str,
+    explicit: Option<std::ffi::OsString>,
+    xdg: Option<std::ffi::OsString>,
+    home: Option<std::ffi::OsString>,
+    home_suffix: &str,
+    herdr_suffix: PathBuf,
+) -> Result<PathBuf, PathError> {
+    if let Some(path) = explicit {
         return Ok(PathBuf::from(path));
     }
-    let base = env::var_os(xdg)
+    let base = xdg
         .map(PathBuf::from)
-        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(home_suffix)))
-        .ok_or(PathError::Unresolved { name: explicit })?;
+        .or_else(|| home.map(|home| PathBuf::from(home).join(home_suffix)))
+        .ok_or(PathError::Unresolved {
+            name: explicit_name,
+        })?;
     Ok(base.join(herdr_suffix))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn explicit_environment_wins_and_well_known_layout_is_fallback() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        env::set_var("HERDR_PLUGIN_STATE_DIR", "/explicit/state");
-        env::set_var("XDG_STATE_HOME", "/xdg/state");
-        assert_eq!(state_dir().unwrap(), PathBuf::from("/explicit/state"));
-        env::remove_var("HERDR_PLUGIN_STATE_DIR");
         assert_eq!(
-            state_dir().unwrap(),
+            resolve_dir_values(
+                "HERDR_PLUGIN_STATE_DIR",
+                Some("/explicit/state".into()),
+                Some("/xdg/state".into()),
+                None,
+                ".local/state",
+                Path::new("herdr/plugins").join(PLUGIN_ID),
+            )
+            .unwrap(),
+            PathBuf::from("/explicit/state")
+        );
+        assert_eq!(
+            resolve_dir_values(
+                "HERDR_PLUGIN_STATE_DIR",
+                None,
+                Some("/xdg/state".into()),
+                None,
+                ".local/state",
+                Path::new("herdr/plugins").join(PLUGIN_ID),
+            )
+            .unwrap(),
             PathBuf::from("/xdg/state/herdr/plugins").join(PLUGIN_ID)
         );
-        env::remove_var("XDG_STATE_HOME");
     }
 
     #[test]
     fn missing_environment_has_a_clear_error() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        let saved = ["HERDR_PLUGIN_CONFIG_DIR", "XDG_CONFIG_HOME", "HOME"]
-            .map(|key| (key, env::var_os(key)));
-        for (key, _) in &saved {
-            env::remove_var(key);
-        }
-        assert!(config_dir()
-            .unwrap_err()
-            .to_string()
-            .contains("HERDR_PLUGIN_CONFIG_DIR"));
-        for (key, value) in saved {
-            if let Some(value) = value {
-                env::set_var(key, value);
-            }
-        }
+        assert!(resolve_dir_values(
+            "HERDR_PLUGIN_CONFIG_DIR",
+            None,
+            None,
+            None,
+            ".config",
+            Path::new("herdr/plugins/config").join(PLUGIN_ID),
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("HERDR_PLUGIN_CONFIG_DIR"));
+    }
+
+    #[test]
+    fn plugin_id_matches_the_authored_manifest() {
+        let manifest: toml::Value = toml::from_str(include_str!("../herdr-plugin.toml")).unwrap();
+        assert_eq!(manifest["id"].as_str(), Some(PLUGIN_ID));
     }
 }

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -80,6 +80,9 @@ pub enum ReconciliationAction {
 /// Additive hook-owned metadata persisted as `[hook]` in `run.toml`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HookMetadata {
+    /// Last report modification time acknowledged by `report` (spec section 13).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub report_read_mtime_ms: BTreeMap<String, u64>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub worker_status: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/src/run.rs
+++ b/src/run.rs
@@ -140,6 +140,10 @@ pub fn save_run_with_hook(run: &RunBoard, hook: &HookMetadata) -> Result<(), Run
             contents.push_str("\n[hook.attention_pending]\n");
             contents.push_str(&toml::to_string(&hook.attention_pending)?);
         }
+        if !hook.report_read_mtime_ms.is_empty() {
+            contents.push_str("\n[hook.report_read_mtime_ms]\n");
+            contents.push_str(&toml::to_string(&hook.report_read_mtime_ms)?);
+        }
         if !hook.aggregate_notifications.is_empty() {
             contents.push_str("\n[hook.aggregate_notifications]\n");
             contents.push_str(&toml::to_string(&hook.aggregate_notifications)?);


### PR DESCRIPTION
## Summary
- add bounded durable team waits over run state and report files
- add inbox/report read tracking and direct-invocation path resolution
- add all/subset message fan-out through existing outbox discipline

## Verification
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test (144 passed)

Closes #23. Closes #24.