### PR TITLE
fix: resolve waits for terminal workers

### DIFF
--- a/src/god_cli.rs
+++ b/src/god_cli.rs
@@ -249,10 +249,10 @@ fn dead_worker(s: &GodSnapshot, until: &Until) -> Option<String> {
         Until::AllTerminal => false,
     };
     s.worker_lifecycles.iter().find_map(|(name, state)| {
-        let dead = matches!(state, WorkerLifecycle::Failed | WorkerLifecycle::Orphaned)
-            || (matches!(until, Until::Blocked | Until::Attention) && terminal(*state));
-        (required(name) && dead && !s.rows.iter().any(|r| r.worker == *name && r.report_present))
-            .then(|| name.clone())
+        (required(name)
+            && terminal(*state)
+            && !s.rows.iter().any(|r| r.worker == *name && r.report_present))
+        .then(|| name.clone())
     })
 }
 
@@ -587,6 +587,25 @@ mod tests {
                 .exit_code(),
             2
         );
+    }
+
+    #[test]
+    fn ended_worker_without_report_makes_report_waits_unsatisfiable() {
+        let ended = snap(false, "done", WorkerLifecycle::Ended);
+
+        for until in [
+            Until::Report("a".into()),
+            Until::AnyReport,
+            Until::AllReports,
+        ] {
+            let fake = Fake {
+                snapshots: std::sync::Mutex::new(vec![ended.clone()]),
+            };
+            let verdict = wait_with(&fake, &until, Duration::ZERO).unwrap();
+            assert_eq!(verdict.verdict, VerdictKind::DeadWorker);
+            assert_eq!(verdict.worker.as_deref(), Some("a"));
+            assert_eq!(verdict.exit_code(), 3);
+        }
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -219,8 +219,16 @@ pub fn list_active_runs(state_dir: &Path) -> Result<Vec<RunBoard>, RunError> {
             }
         }
     }
-    runs.sort_unstable_by(|left, right| left.dir.cmp(&right.dir));
+    runs.sort_unstable_by(|left, right| {
+        run_creation_timestamp(&left.dir)
+            .cmp(&run_creation_timestamp(&right.dir))
+            .then_with(|| left.dir.cmp(&right.dir))
+    });
     Ok(runs)
+}
+
+fn run_creation_timestamp(path: &Path) -> Option<u128> {
+    path.file_name()?.to_str()?.rsplit_once('-')?.1.parse().ok()
 }
 
 pub fn match_pane(state_dir: &Path, pane_id: &str) -> Result<Option<MatchedWorker>, RunError> {
@@ -545,6 +553,28 @@ lifecycle = "running"
         assert!(list_active_runs(temp.path())
             .expect("list missing runs directory")
             .is_empty());
+    }
+
+    #[test]
+    fn active_runs_sort_by_creation_suffix_not_team_name() {
+        let temp = TempDir::new();
+        let runs = temp.path().join(RUNS_DIR);
+        fs::create_dir(&runs).unwrap();
+
+        for (directory, team) in [("wave6b-100", "wave6b"), ("dod6-200", "dod6")] {
+            let dir = runs.join(directory);
+            fs::create_dir(&dir).unwrap();
+            let run = RunBoard {
+                dir,
+                state: run_state(team, &format!("pane-{team}")),
+            };
+            save_run_with_hook(&run, &HookMetadata::default()).unwrap();
+        }
+
+        let mut active = list_active_runs(temp.path()).unwrap();
+        assert_eq!(active[0].state.spec.name, "wave6b");
+        assert_eq!(active[1].state.spec.name, "dod6");
+        assert_eq!(active.pop().unwrap().state.spec.name, "dod6");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- treat every terminal worker lifecycle as unsatisfiable for report-based waits when its report is absent
- preserve literal `all-terminal` success semantics
- select the newest active run by numeric creation timestamp suffix, not team-name/path lexicographic order or directory mtime
- cover ended workers across report waits and contradictory lexical/timestamp run ordering

## Verification
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test (151 passed)
- 15 consecutive full test-suite runs after each finding
