### PR TITLE
docs: relink procedure + codex prompting skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ cargo build --release
 herdr plugin link .
 ```
 
+### Upgrade or relink after manifest changes
+
+Herdr caches `herdr-plugin.toml` when a plugin is linked. After **any** manifest
+change, `herdr plugin disable` followed by `herdr plugin enable` still serves
+the cached manifest. The failure signature is a stale reported version and new
+events or panes that are missing or never fire.
+
+Force Herdr to read the manifest again:
+
+```bash
+herdr plugin unlink caioniehues.agent-team
+herdr plugin link /absolute/path/to/herdr-agent-team
+```
+
+Use that relink as the mandatory post-release smoke test, then read the linked
+plugin's reported version back and confirm it matches the release. This is a
+documentation workaround for current Herdr cache invalidation; if upstream
+later reloads changed manifests automatically, retain it as historical release
+guidance.
+
 For direct terminal use, put the linked or installed binary on `PATH` once:
 
 ```bash

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -173,6 +173,14 @@ no-op with a clear message.
   turn completion: upstream can report background-wait panes as `idle`/`done`
   while work remains (`ogulcancelik/herdr#1217`). The durable report and its
   sentinel remain the completion truth.
+- Manifest registrations are cached at link time. After any
+  `herdr-plugin.toml` change, `herdr plugin disable` plus `enable` is
+  insufficient: a stale reported version and missing/non-firing events or panes
+  mean Herdr is still serving the cached manifest. Run
+  `herdr plugin unlink caioniehues.agent-team`, then
+  `herdr plugin link <absolute-plugin-path>`. Every post-release smoke test must
+  relink and read the reported version back. If upstream later invalidates this
+  cache automatically, this remains historical release guidance.
 
 ## 6. `team status` / `team kill`
 

--- a/skills/codex-prompting/SKILL.md
+++ b/skills/codex-prompting/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: codex-prompting
+description: Drive Codex pane workers from a god session. Use when writing Codex briefs, choosing Codex launcher flags or models, sending mid-turn follow-ups, or translating a Claude skill-dependent task for a Codex worker.
+---
+
+# Codex worker prompting
+
+Treat Codex as its own launcher, not as Claude Code with a different binary.
+Write a self-contained brief, preserve the repository-authored `AGENTS.md`, and
+pass the generated worker protocol by absolute-path pointer injection.
+
+## Discover the live command surface
+
+Run `codex --version` and `codex --help` before relying on a release-specific
+flag. In an interactive Codex pane, type `/` without submitting; read the popup
+as the live slash-command authority. Recheck after every Codex upgrade.
+
+Live-verified against `codex-cli 0.144.4` on 2026-07-15:
+
+```text
+/model /fast /ide /permissions /keymap /vim /experimental /approve
+/memories /skills /import /hooks /review /rename /new /archive /delete
+/resume /fork /init /compact /plan /goal /agent /side /copy /raw /diff
+/mention /status /usage /title /statusline /theme /pets /mcp /plugins
+/logout /exit /feedback /ps /stop /clear /personality /subagents
+```
+
+The popup is contextual: feature-gated or unavailable commands may be hidden.
+Do not copy a list from another Codex release into a brief without probing the
+target pane.
+
+## Write Codex-native briefs
+
+- Put durable project rules in repository-authored `AGENTS.md`. Codex loads
+  applicable `AGENTS.md` files natively from the project hierarchy.
+- Keep the generated worker protocol separate. Inject its absolute path and the
+  brief's absolute path; do not overwrite or synthesize repository
+  `AGENTS.md`.
+- Inline every required procedure, checklist, template, and acceptance rule in
+  the brief or a named file the brief orders Codex to read. Codex does not load
+  Claude Code user-level skills or accept their slash invocations. A command
+  such as `/ask-matt` fails with `Unrecognized command`.
+- Route a task whose behavior depends on a Claude skill to a Claude worker, or
+  inline that skill's relevant content into the Codex brief. Claude pane
+  workers do load user-level Claude skills `[live 2026-07-15]`.
+- Specify owned files, exclusions, exact verification commands, Git contract,
+  report path, and completion sentinel. Assume no implied workflow from a
+  coordinator-side skill name.
+
+Codex has its own `/skills` surface in 0.144.4; that does not make Claude Code
+skills or arbitrary Claude slash commands portable.
+
+## Submit and follow up safely
+
+Use one `herdr pane run` per prompt. It sends the text and Enter as one request;
+never split paste and submit. Keep `herdr agent wait --status working` as the
+submission check required by the launcher policy.
+
+Codex queues a mid-turn `pane run` as a separate pending user turn and submits
+it after the active turn finishes `[live 2026-07-15]`. Set
+`queues_midturn = true` only for a Codex version verified this way. Send worker
+messages through the msg verb; never use raw `herdr agent send` as a messaging
+channel.
+
+## Select models and permissions explicitly
+
+Set the launch model with `codex --model <model>` (or `-m <model>`). Change it
+interactively with `/model`. State reasoning or behavior requirements in the
+brief; do not paste Claude-only model directives and assume Codex interprets
+them.
+
+`--dangerously-bypass-approvals-and-sandbox` disables both confirmation prompts
+and Codex sandboxing. It is not merely an automatic-approval flag. Use it only
+when the worker already runs inside an externally enforced sandbox and the
+team explicitly accepts unrestricted execution. The default Codex sandbox can
+deny the Herdr socket used by worker-to-god msg; choose the permissive launcher
+trade-off deliberately rather than weakening every worker by default.


### PR DESCRIPTION
## Summary

- document mandatory unlink/link after every manifest change and the post-release version smoke test
- add a coordinator-side Codex prompting skill with the live 0.144.4 command surface and Codex-specific brief guidance

## Verification

- `cargo fmt --check`
- `cargo test` (151 passed)

Closes #16. Closes #34.