### PR TITLE
fix: run.toml write consistency + adoptee recovery

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -512,9 +512,12 @@ herdr-agent-team adopt <pane-id> --name <worker> [--role <text>]
   (launch-prompt style); otherwise protocol pointer only.
 - **Crash recovery:** rerunning `adopt` with the same worker name and pane
   completes a persisted `pending` adoptee through protocol generation and
-  prompt submission, then marks it `running`. It never runs a launcher command
-  in the existing pane. Rerunning it for an already-running adoptee is an
-  idempotent no-op with a clear message; other duplicate names remain errors.
+  prompt submission, then atomically records launch checkpoint
+  `brief_submitted` and marks it `running`. If that checkpoint was already
+  persisted, recovery completes the pending lifecycle without resubmitting the
+  prompt. It never runs a launcher command in the existing pane. Rerunning it
+  for an already-running adoptee is an idempotent no-op with a clear message;
+  other duplicate names remain errors.
 - **Kill semantics:** `team kill` closes only plugin-created workspaces.
   Adopted workers are marked `released` in `run.toml` and receive one
   injected release notice; their panes and workspaces survive.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -135,6 +135,8 @@ Given a spec (file or shorthand):
       advisory file lock around a fresh load, narrow mutation/reconciliation,
       and the existing atomic temp-file rename. Spawn threads and separate hook
       processes therefore cannot overwrite one another with stale snapshots.
+      All later `run.toml` mutations, including adopt, attention, and kill,
+      use this same transaction; unlocked save helpers are test-only.
 6. After brief submission, poll lazily for each optional Herdr `agent_session`.
    Persist it when available; missing identity does not delay this or another
    worker's brief and does not fail an otherwise running worker.
@@ -508,6 +510,11 @@ herdr-agent-team adopt <pane-id> --name <worker> [--role <text>]
   `agents.toml` entry to add. No detected agent → refuse.
 - **Brief:** `--brief` injects brief + protocol pointers in one line
   (launch-prompt style); otherwise protocol pointer only.
+- **Crash recovery:** rerunning `adopt` with the same worker name and pane
+  completes a persisted `pending` adoptee through protocol generation and
+  prompt submission, then marks it `running`. It never runs a launcher command
+  in the existing pane. Rerunning it for an already-running adoptee is an
+  idempotent no-op with a clear message; other duplicate names remain errors.
 - **Kill semantics:** `team kill` closes only plugin-created workspaces.
   Adopted workers are marked `released` in `run.toml` and receive one
   injected release notice; their panes and workspaces survive.

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -338,8 +338,9 @@ fn adopt_resolved<H: HerdrApi>(
         brief: arguments.brief.clone().unwrap_or_default(),
     };
 
-    let (mut run, worker, mut disposition) = match target {
-        RunTarget::Existing(run) => prepare_existing_run(*run, requested_worker, &pane)?,
+    let (mut run, worker, disposition, bootstrapped) = match target {
+        RunTarget::Existing(run) => prepare_existing_run(*run, requested_worker, &pane)
+            .map(|(run, worker, disposition)| (run, worker, disposition, false))?,
         RunTarget::Bootstrap => bootstrap_run(
             state_dir,
             arguments.team.as_deref().unwrap_or(DEFAULT_TEAM),
@@ -347,7 +348,7 @@ fn adopt_resolved<H: HerdrApi>(
             &requested_worker,
             &pane,
         )
-        .map(|run| (run, requested_worker, AdoptDisposition::Adopted))?,
+        .map(|run| (run, requested_worker, AdoptDisposition::Adopted, true))?,
     };
     if disposition == AdoptDisposition::NothingToDo {
         return Ok(AdoptOutcome {
@@ -360,16 +361,37 @@ fn adopt_resolved<H: HerdrApi>(
     let (fresh, should_submit) =
         update_run_with_hook(&run.dir, |fresh, _| -> Result<bool, AdoptError> {
             fresh.state.herdr_session = session;
-            if disposition == AdoptDisposition::Adopted
-                && !fresh.state.workers.contains_key(&worker.name)
-            {
-                validate_new_worker(fresh, &worker, &pane)?;
-                insert_adopted_worker(&mut fresh.state, &worker, &pane);
+            if disposition == AdoptDisposition::Adopted {
+                if bootstrapped {
+                    validate_recovery_worker(fresh, &worker, &pane)?;
+                } else {
+                    validate_new_worker(fresh, &worker, &pane)?;
+                    insert_adopted_worker(&mut fresh.state, &worker, &pane);
+                }
+            }
+            let state = fresh.state.workers.get_mut(&worker.name).ok_or_else(|| {
+                AdoptError::DuplicateWorker {
+                    worker: worker.name.clone(),
+                    run_dir: fresh.dir.clone(),
+                }
+            })?;
+            if state.pane_id.as_deref() != Some(&pane.pane_id) || !state.adopted {
+                return Err(AdoptError::DuplicateWorker {
+                    worker: worker.name.clone(),
+                    run_dir: fresh.dir.clone(),
+                });
             }
             if disposition == AdoptDisposition::Recovered {
-                return match fresh.state.workers[&worker.name].lifecycle {
-                    WorkerLifecycle::Pending => Ok(true),
-                    WorkerLifecycle::Running => Ok(false),
+                return match (state.lifecycle, state.launch_checkpoint) {
+                    (
+                        WorkerLifecycle::Pending,
+                        crate::types::WorkerLaunchCheckpoint::BriefSubmitted,
+                    ) => {
+                        state.lifecycle = WorkerLifecycle::Running;
+                        Ok(false)
+                    }
+                    (WorkerLifecycle::Pending, _) => Ok(true),
+                    (WorkerLifecycle::Running, _) => Ok(false),
                     _ => Err(AdoptError::DuplicateWorker {
                         worker: worker.name.clone(),
                         run_dir: fresh.dir.clone(),
@@ -380,7 +402,6 @@ fn adopt_resolved<H: HerdrApi>(
         })?;
     run = fresh;
     if !should_submit {
-        disposition = AdoptDisposition::NothingToDo;
         return Ok(AdoptOutcome {
             run,
             unknown_agent,
@@ -410,7 +431,7 @@ fn adopt_resolved<H: HerdrApi>(
         update_adopted_lifecycle(&mut run, &worker.name, WorkerLifecycle::Failed)?;
         return Err(error.into());
     }
-    update_adopted_lifecycle(&mut run, &worker.name, WorkerLifecycle::Running)?;
+    complete_adopted_submission(&mut run, &worker.name)?;
     Ok(AdoptOutcome {
         run,
         unknown_agent,
@@ -513,17 +534,60 @@ fn validate_new_worker(
     Ok(())
 }
 
+fn validate_recovery_worker(
+    run: &RunBoard,
+    worker: &WorkerSpec,
+    pane: &PaneInfo,
+) -> Result<(), AdoptError> {
+    let state = run
+        .state
+        .workers
+        .get(&worker.name)
+        .ok_or_else(|| AdoptError::DuplicateWorker {
+            worker: worker.name.clone(),
+            run_dir: run.dir.clone(),
+        })?;
+    if !state.adopted || state.pane_id.as_deref() != Some(&pane.pane_id) {
+        return Err(AdoptError::DuplicateWorker {
+            worker: worker.name.clone(),
+            run_dir: run.dir.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn complete_adopted_submission(run: &mut RunBoard, worker_name: &str) -> Result<(), AdoptError> {
+    let (fresh, ()) = update_run_with_hook(&run.dir, |fresh, _| -> Result<(), AdoptError> {
+        let run_dir = fresh.dir.clone();
+        let worker = fresh.state.workers.get_mut(worker_name).ok_or_else(|| {
+            AdoptError::DuplicateWorker {
+                worker: worker_name.to_owned(),
+                run_dir,
+            }
+        })?;
+        worker.launch_checkpoint = crate::types::WorkerLaunchCheckpoint::BriefSubmitted;
+        if worker.lifecycle == WorkerLifecycle::Pending {
+            worker.lifecycle = WorkerLifecycle::Running;
+        }
+        Ok(())
+    })?;
+    *run = fresh;
+    Ok(())
+}
+
 fn update_adopted_lifecycle(
     run: &mut RunBoard,
     worker_name: &str,
     lifecycle: WorkerLifecycle,
 ) -> Result<(), AdoptError> {
     let (fresh, ()) = update_run_with_hook(&run.dir, |fresh, _| -> Result<(), AdoptError> {
-        let worker = fresh
-            .state
-            .workers
-            .get_mut(worker_name)
-            .expect("adopted worker exists in persisted run state");
+        let run_dir = fresh.dir.clone();
+        let worker = fresh.state.workers.get_mut(worker_name).ok_or_else(|| {
+            AdoptError::DuplicateWorker {
+                worker: worker_name.to_owned(),
+                run_dir,
+            }
+        })?;
         if worker.lifecycle == WorkerLifecycle::Pending {
             worker.lifecycle = lifecycle;
         }
@@ -894,14 +958,64 @@ mod tests {
             outcome.run.state.workers["newcomer"].lifecycle,
             WorkerLifecycle::Running
         );
-        assert!(fake
-            .calls()
+        let pane_runs = fake
+            .typed_calls
+            .borrow()
             .iter()
-            .any(|call| call.starts_with("pane_run:pane-adopted:The repository")));
+            .filter(|call| matches!(call, crate::herdr::test_support::FakeCall::PaneRun(..)))
+            .count();
+        assert_eq!(
+            pane_runs, 1,
+            "recovery submits one prompt and no launcher command"
+        );
+    }
+
+    #[test]
+    fn recovered_brief_checkpoint_skips_duplicate_submission() {
+        let temp = TempDir::new();
+        let mut run = existing_run(temp.path(), Topology::Star);
+        let fake = fake_herdr(temp.path(), Some("codex"));
+        let worker = WorkerSpec {
+            name: "newcomer".to_owned(),
+            agent: "codex".to_owned(),
+            role: DEFAULT_ROLE.to_owned(),
+            task: None,
+            worktree: false,
+            branch: None,
+            brief: PathBuf::new(),
+        };
+        insert_adopted_worker(
+            &mut run.state,
+            &worker,
+            fake.pane.borrow().as_ref().unwrap(),
+        );
+        run.state
+            .workers
+            .get_mut("newcomer")
+            .unwrap()
+            .launch_checkpoint = crate::types::WorkerLaunchCheckpoint::BriefSubmitted;
+        crate::run::save_run(&run).unwrap();
+
+        let outcome = adopt_resolved(
+            adopted_arguments("newcomer"),
+            RunTarget::Existing(Box::new(run)),
+            temp.path(),
+            "god-pane",
+            &default_launcher_table(),
+            &fake,
+        )
+        .unwrap();
+
+        assert_eq!(outcome.disposition, AdoptDisposition::Recovered);
+        assert_eq!(
+            outcome.run.state.workers["newcomer"].lifecycle,
+            WorkerLifecycle::Running
+        );
         assert!(!fake
-            .calls()
+            .typed_calls
+            .borrow()
             .iter()
-            .any(|call| call.starts_with("pane_run:pane-adopted:'")));
+            .any(|call| matches!(call, crate::herdr::test_support::FakeCall::PaneRun(..))));
     }
 
     #[test]

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -2,7 +2,9 @@
 
 use crate::herdr::{HerdrApi, HerdrClient, HerdrError, PaneInfo};
 use crate::launcher::{conservative_adopted_launcher, load_from_env, LauncherError};
-use crate::run::{create_run, list_active_runs, load_run, save_run, RunBoard, RunError};
+use crate::run::{
+    create_run, list_active_runs, load_run, update_run_with_hook, RunBoard, RunError,
+};
 use crate::spawn::{
     adoption_prompt, is_safe_worker_filename, submit_worker_prompt, worker_protocol_path,
     write_worker_protocol, SpawnError,
@@ -101,6 +103,14 @@ enum RunTarget {
 struct AdoptOutcome {
     run: RunBoard,
     unknown_agent: Option<String>,
+    disposition: AdoptDisposition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AdoptDisposition {
+    Adopted,
+    Recovered,
+    NothingToDo,
 }
 
 pub fn adopt_command(args: &[String]) -> Result<(), AdoptError> {
@@ -148,10 +158,20 @@ pub fn adopt_command(args: &[String]) -> Result<(), AdoptError> {
     if let Some(agent) = outcome.unknown_agent.as_deref() {
         eprintln!("{}", unknown_agent_warning(agent));
     }
-    println!(
-        "worker adopted into team run: {}",
-        outcome.run.dir.display()
-    );
+    match outcome.disposition {
+        AdoptDisposition::Adopted => println!(
+            "worker adopted into team run: {}",
+            outcome.run.dir.display()
+        ),
+        AdoptDisposition::Recovered => println!(
+            "pending adopted worker recovered in team run: {}",
+            outcome.run.dir.display()
+        ),
+        AdoptDisposition::NothingToDo => println!(
+            "adopted worker is already healthy; nothing to do: {}",
+            outcome.run.dir.display()
+        ),
+    }
     Ok(())
 }
 
@@ -308,7 +328,7 @@ fn adopt_resolved<H: HerdrApi>(
         })?
         .to_owned();
     let (launcher, unknown_agent) = adoption_launcher(launchers, &agent);
-    let worker = WorkerSpec {
+    let requested_worker = WorkerSpec {
         name: arguments.name,
         agent,
         role: arguments.role,
@@ -318,19 +338,55 @@ fn adopt_resolved<H: HerdrApi>(
         brief: arguments.brief.clone().unwrap_or_default(),
     };
 
-    let mut run = match target {
-        RunTarget::Existing(run) => prepare_existing_run(*run, &worker, &pane)?,
+    let (mut run, worker, mut disposition) = match target {
+        RunTarget::Existing(run) => prepare_existing_run(*run, requested_worker, &pane)?,
         RunTarget::Bootstrap => bootstrap_run(
             state_dir,
             arguments.team.as_deref().unwrap_or(DEFAULT_TEAM),
             god_pane_id,
-            &worker,
+            &requested_worker,
             &pane,
-        )?,
+        )
+        .map(|run| (run, requested_worker, AdoptDisposition::Adopted))?,
     };
-    run.state.herdr_session = current_herdr_session_identity();
-
-    save_run(&run)?;
+    if disposition == AdoptDisposition::NothingToDo {
+        return Ok(AdoptOutcome {
+            run,
+            unknown_agent,
+            disposition,
+        });
+    }
+    let session = current_herdr_session_identity();
+    let (fresh, should_submit) =
+        update_run_with_hook(&run.dir, |fresh, _| -> Result<bool, AdoptError> {
+            fresh.state.herdr_session = session;
+            if disposition == AdoptDisposition::Adopted
+                && !fresh.state.workers.contains_key(&worker.name)
+            {
+                validate_new_worker(fresh, &worker, &pane)?;
+                insert_adopted_worker(&mut fresh.state, &worker, &pane);
+            }
+            if disposition == AdoptDisposition::Recovered {
+                return match fresh.state.workers[&worker.name].lifecycle {
+                    WorkerLifecycle::Pending => Ok(true),
+                    WorkerLifecycle::Running => Ok(false),
+                    _ => Err(AdoptError::DuplicateWorker {
+                        worker: worker.name.clone(),
+                        run_dir: fresh.dir.clone(),
+                    }),
+                };
+            }
+            Ok(true)
+        })?;
+    run = fresh;
+    if !should_submit {
+        disposition = AdoptDisposition::NothingToDo;
+        return Ok(AdoptOutcome {
+            run,
+            unknown_agent,
+            disposition,
+        });
+    }
     let mut protocol_team = run.state.spec.clone();
     if let Some(cwd) = pane.cwd.clone() {
         protocol_team.cwd = cwd;
@@ -351,32 +407,22 @@ fn adopt_resolved<H: HerdrApi>(
         &prompt,
         launcher.submit_verify,
     ) {
-        run.state
-            .workers
-            .get_mut(&worker.name)
-            .expect("adopted worker was inserted before protocol generation")
-            .lifecycle = WorkerLifecycle::Failed;
-        save_run(&run)?;
+        update_adopted_lifecycle(&mut run, &worker.name, WorkerLifecycle::Failed)?;
         return Err(error.into());
     }
-
-    run.state
-        .workers
-        .get_mut(&worker.name)
-        .expect("adopted worker was inserted before protocol generation")
-        .lifecycle = WorkerLifecycle::Running;
-    save_run(&run)?;
-
-    // Keep the in-memory return value synchronized with the final persisted state.
-    run = load_run(&run.dir)?;
-    Ok(AdoptOutcome { run, unknown_agent })
+    update_adopted_lifecycle(&mut run, &worker.name, WorkerLifecycle::Running)?;
+    Ok(AdoptOutcome {
+        run,
+        unknown_agent,
+        disposition,
+    })
 }
 
 fn prepare_existing_run(
-    mut run: RunBoard,
-    worker: &WorkerSpec,
+    run: RunBoard,
+    worker: WorkerSpec,
     pane: &PaneInfo,
-) -> Result<RunBoard, AdoptError> {
+) -> Result<(RunBoard, WorkerSpec, AdoptDisposition), AdoptError> {
     if run.state.lifecycle != RunLifecycle::Active {
         return Err(AdoptError::InactiveRun {
             run_dir: run.dir.clone(),
@@ -387,6 +433,59 @@ fn prepare_existing_run(
             run_dir: run.dir.clone(),
         });
     }
+    if let (Some(state), Some(existing)) = (
+        run.state.workers.get(&worker.name),
+        run.state
+            .spec
+            .workers
+            .iter()
+            .find(|existing| existing.name == worker.name)
+            .cloned(),
+    ) {
+        if state.adopted && state.pane_id.as_deref() == Some(&pane.pane_id) {
+            return match state.lifecycle {
+                WorkerLifecycle::Pending => Ok((run, existing, AdoptDisposition::Recovered)),
+                WorkerLifecycle::Running => Ok((run, existing, AdoptDisposition::NothingToDo)),
+                _ => Err(AdoptError::DuplicateWorker {
+                    worker: worker.name,
+                    run_dir: run.dir.clone(),
+                }),
+            };
+        }
+    }
+    if run.state.workers.contains_key(&worker.name)
+        || run
+            .state
+            .spec
+            .workers
+            .iter()
+            .any(|existing| existing.name == worker.name)
+    {
+        return Err(AdoptError::DuplicateWorker {
+            worker: worker.name,
+            run_dir: run.dir.clone(),
+        });
+    }
+    if run
+        .state
+        .workers
+        .values()
+        .any(|existing| existing.pane_id.as_deref() == Some(&pane.pane_id))
+    {
+        return Err(AdoptError::DuplicatePane {
+            pane_id: pane.pane_id.clone(),
+            run_dir: run.dir.clone(),
+        });
+    }
+
+    Ok((run, worker, AdoptDisposition::Adopted))
+}
+
+fn validate_new_worker(
+    run: &RunBoard,
+    worker: &WorkerSpec,
+    pane: &PaneInfo,
+) -> Result<(), AdoptError> {
     if run.state.workers.contains_key(&worker.name)
         || run
             .state
@@ -411,9 +510,27 @@ fn prepare_existing_run(
             run_dir: run.dir.clone(),
         });
     }
+    Ok(())
+}
 
-    insert_adopted_worker(&mut run.state, worker, pane);
-    Ok(run)
+fn update_adopted_lifecycle(
+    run: &mut RunBoard,
+    worker_name: &str,
+    lifecycle: WorkerLifecycle,
+) -> Result<(), AdoptError> {
+    let (fresh, ()) = update_run_with_hook(&run.dir, |fresh, _| -> Result<(), AdoptError> {
+        let worker = fresh
+            .state
+            .workers
+            .get_mut(worker_name)
+            .expect("adopted worker exists in persisted run state");
+        if worker.lifecycle == WorkerLifecycle::Pending {
+            worker.lifecycle = lifecycle;
+        }
+        Ok(())
+    })?;
+    *run = fresh;
+    Ok(())
 }
 
 fn bootstrap_run(
@@ -739,6 +856,152 @@ mod tests {
         assert!(calls
             .iter()
             .any(|call| call == "agent_wait:pane-adopted:working"));
+    }
+
+    #[test]
+    fn pending_adoptee_rerun_recovers_without_launching_agent_cli() {
+        let temp = TempDir::new();
+        let mut run = existing_run(temp.path(), Topology::Star);
+        let fake = fake_herdr(temp.path(), Some("codex"));
+        let worker = WorkerSpec {
+            name: "newcomer".to_owned(),
+            agent: "codex".to_owned(),
+            role: DEFAULT_ROLE.to_owned(),
+            task: None,
+            worktree: false,
+            branch: None,
+            brief: PathBuf::new(),
+        };
+        insert_adopted_worker(
+            &mut run.state,
+            &worker,
+            fake.pane.borrow().as_ref().unwrap(),
+        );
+        crate::run::save_run(&run).unwrap();
+
+        let outcome = adopt_resolved(
+            adopted_arguments("newcomer"),
+            RunTarget::Existing(Box::new(run)),
+            temp.path(),
+            "god-pane",
+            &default_launcher_table(),
+            &fake,
+        )
+        .expect("pending adoptee should recover");
+
+        assert_eq!(outcome.disposition, AdoptDisposition::Recovered);
+        assert_eq!(
+            outcome.run.state.workers["newcomer"].lifecycle,
+            WorkerLifecycle::Running
+        );
+        assert!(fake
+            .calls()
+            .iter()
+            .any(|call| call.starts_with("pane_run:pane-adopted:The repository")));
+        assert!(!fake
+            .calls()
+            .iter()
+            .any(|call| call.starts_with("pane_run:pane-adopted:'")));
+    }
+
+    #[test]
+    fn healthy_adoptee_rerun_is_a_no_op() {
+        let temp = TempDir::new();
+        let run = existing_run(temp.path(), Topology::Star);
+        let fake = fake_herdr(temp.path(), Some("codex"));
+        let first = adopt_resolved(
+            adopted_arguments("newcomer"),
+            RunTarget::Existing(Box::new(run)),
+            temp.path(),
+            "god-pane",
+            &default_launcher_table(),
+            &fake,
+        )
+        .unwrap();
+        let second_fake = fake_herdr(temp.path(), Some("codex"));
+        let second = adopt_resolved(
+            adopted_arguments("newcomer"),
+            RunTarget::Existing(Box::new(first.run)),
+            temp.path(),
+            "god-pane",
+            &default_launcher_table(),
+            &second_fake,
+        )
+        .unwrap();
+
+        assert_eq!(second.disposition, AdoptDisposition::NothingToDo);
+        assert_eq!(second_fake.calls(), ["pane_get:pane-adopted"]);
+    }
+
+    #[test]
+    fn adopt_saves_preserve_fresher_hook_state() {
+        let temp = TempDir::new();
+        let stale = existing_run(temp.path(), Topology::Star);
+        crate::run::update_run_with_hook(&stale.dir, |fresh, hook| -> Result<(), AdoptError> {
+            fresh.state.workers.get_mut("existing").unwrap().lifecycle = WorkerLifecycle::Orphaned;
+            hook.attention_pending.insert("existing".to_owned(), true);
+            Ok(())
+        })
+        .unwrap();
+        let run_dir = stale.dir.clone();
+        let fake = fake_herdr(temp.path(), Some("codex"));
+
+        adopt_resolved(
+            adopted_arguments("newcomer"),
+            RunTarget::Existing(Box::new(stale)),
+            temp.path(),
+            "god-pane",
+            &default_launcher_table(),
+            &fake,
+        )
+        .unwrap();
+
+        let persisted = load_run(&run_dir).unwrap();
+        assert_eq!(
+            persisted.state.workers["existing"].lifecycle,
+            WorkerLifecycle::Orphaned
+        );
+        assert_eq!(
+            crate::run::load_hook_metadata(&persisted.dir)
+                .unwrap()
+                .attention_pending
+                .get("existing"),
+            Some(&true)
+        );
+    }
+
+    #[test]
+    fn adopt_lifecycle_save_preserves_a_fresher_hook_lifecycle() {
+        let temp = TempDir::new();
+        let mut run = existing_run(temp.path(), Topology::Star);
+        let worker = WorkerSpec {
+            name: "newcomer".to_owned(),
+            agent: "codex".to_owned(),
+            role: DEFAULT_ROLE.to_owned(),
+            task: None,
+            worktree: false,
+            branch: None,
+            brief: PathBuf::new(),
+        };
+        let pane = fake_herdr(temp.path(), Some("codex"))
+            .pane
+            .borrow()
+            .clone()
+            .unwrap();
+        insert_adopted_worker(&mut run.state, &worker, &pane);
+        crate::run::save_run(&run).unwrap();
+        crate::run::update_run_with_hook(&run.dir, |fresh, _| -> Result<(), AdoptError> {
+            fresh.state.workers.get_mut("newcomer").unwrap().lifecycle = WorkerLifecycle::Orphaned;
+            Ok(())
+        })
+        .unwrap();
+
+        update_adopted_lifecycle(&mut run, "newcomer", WorkerLifecycle::Running).unwrap();
+
+        assert_eq!(
+            run.state.workers["newcomer"].lifecycle,
+            WorkerLifecycle::Orphaned
+        );
     }
 
     #[test]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -4,9 +4,7 @@ use crate::herdr::{HerdrApi, HerdrClient, HerdrError, WaitOutcome};
 use crate::launcher::{
     conservative_adopted_launcher, launcher_entry, load_from_env, LauncherError,
 };
-use crate::run::{
-    list_active_runs, load_hook_metadata, load_run, save_run_with_hook, RunBoard, RunError,
-};
+use crate::run::{list_active_runs, load_run, update_run_with_hook, RunBoard, RunError};
 use crate::types::{LauncherEntry, LauncherTable, RunLifecycle};
 use std::collections::BTreeSet;
 use std::env;
@@ -288,13 +286,13 @@ fn request_attention_from_pane<H: HerdrApi>(
             (worker.pane_id.as_deref() == Some(source_pane)).then(|| name.clone())
         })
         .ok_or(MsgError::AttentionSource)?;
-    let mut metadata = load_hook_metadata(&run.dir)?;
-    metadata.attention_pending.insert(worker_name.clone(), true);
-    let first = metadata
-        .aggregate_notifications
-        .insert(format!("attention:{worker_name}"), true)
-        .is_none();
-    save_run_with_hook(run, &metadata)?;
+    let (_, first) = update_run_with_hook(&run.dir, |_, metadata| -> Result<bool, MsgError> {
+        metadata.attention_pending.insert(worker_name.clone(), true);
+        Ok(metadata
+            .aggregate_notifications
+            .insert(format!("attention:{worker_name}"), true)
+            .is_none())
+    })?;
     if first {
         herdr.notification_show(
             "Worker needs attention",
@@ -1040,6 +1038,36 @@ mod tests {
         assert_eq!(
             metadata.aggregate_notifications.get("attention:builder"),
             Some(&true)
+        );
+    }
+
+    #[test]
+    fn attention_writer_preserves_fresher_hook_worker_state() {
+        let temp = TempDir::new();
+        let run = crate::run::create_run(
+            temp.path(),
+            fixture_run(temp.path(), "builder", "claude").state,
+        )
+        .unwrap();
+        let stale = run.clone();
+        crate::run::update_run_with_hook(&run.dir, |fresh, _| -> Result<(), MsgError> {
+            fresh.state.workers.get_mut("builder").unwrap().lifecycle =
+                crate::types::WorkerLifecycle::Orphaned;
+            Ok(())
+        })
+        .unwrap();
+
+        request_attention_from_pane(
+            &stale,
+            "please review",
+            "worker-pane",
+            &fake_herdr("claude", Some("working"), []),
+        )
+        .unwrap();
+
+        assert_eq!(
+            load_run(&run.dir).unwrap().state.workers["builder"].lifecycle,
+            crate::types::WorkerLifecycle::Orphaned
         );
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -79,7 +79,7 @@ pub fn create_run(state_dir: &Path, state: RunState) -> Result<RunBoard, RunErro
         dir: run_dir,
         state,
     };
-    if let Err(error) = save_run_with_hook(&run, &HookMetadata::default()) {
+    if let Err(error) = write_run_with_hook(&run, &HookMetadata::default()) {
         let _ = fs::remove_dir_all(&run.dir);
         return Err(error);
     }
@@ -96,9 +96,10 @@ pub fn load_run(run_dir: &Path) -> Result<RunBoard, RunError> {
     })
 }
 
-pub fn save_run(run: &RunBoard) -> Result<(), RunError> {
+#[cfg(test)]
+pub(crate) fn save_run(run: &RunBoard) -> Result<(), RunError> {
     let hook = load_hook_metadata(&run.dir)?;
-    save_run_with_hook(run, &hook)
+    write_run_with_hook(run, &hook)
 }
 
 pub fn load_hook_metadata(run_dir: &Path) -> Result<HookMetadata, RunError> {
@@ -106,7 +107,12 @@ pub fn load_hook_metadata(run_dir: &Path) -> Result<HookMetadata, RunError> {
     Ok(toml::from_str::<HookEnvelope>(&contents)?.hook)
 }
 
-pub fn save_run_with_hook(run: &RunBoard, hook: &HookMetadata) -> Result<(), RunError> {
+#[cfg(test)]
+pub(crate) fn save_run_with_hook(run: &RunBoard, hook: &HookMetadata) -> Result<(), RunError> {
+    write_run_with_hook(run, hook)
+}
+
+fn write_run_with_hook(run: &RunBoard, hook: &HookMetadata) -> Result<(), RunError> {
     let mut contents = toml::to_string_pretty(&run.state)?;
     if hook != &HookMetadata::default() {
         if let Some(god_workspace_id) = &hook.god_workspace_id {
@@ -176,7 +182,7 @@ where
         let mut run = load_run(run_dir).map_err(E::from)?;
         let mut hook = load_hook_metadata(run_dir).map_err(E::from)?;
         let value = update(&mut run, &mut hook)?;
-        save_run_with_hook(&run, &hook).map_err(E::from)?;
+        write_run_with_hook(&run, &hook).map_err(E::from)?;
         Ok((run, value))
     })();
     let unlock = FileExt::unlock(&lock_file)
@@ -263,7 +269,8 @@ pub fn append_event(run_dir: &Path, event: &Value) -> Result<(), RunError> {
     Ok(())
 }
 
-pub fn mark_ended(run: &mut RunBoard) -> Result<(), RunError> {
+#[cfg(test)]
+pub(crate) fn mark_ended(run: &mut RunBoard) -> Result<(), RunError> {
     let previous = run.state.lifecycle;
     run.state.lifecycle = RunLifecycle::Ended;
     if let Err(error) = save_run(run) {
@@ -590,6 +597,14 @@ lifecycle = "running"
 
         assert!(!worker.adopted);
         assert_eq!(worker.lifecycle, WorkerLifecycle::Running);
+    }
+
+    #[test]
+    fn unlocked_save_helpers_are_test_only() {
+        let source = include_str!("run.rs");
+        assert!(source.contains("#[cfg(test)]\npub(crate) fn save_run("));
+        assert!(source.contains("#[cfg(test)]\npub(crate) fn save_run_with_hook("));
+        assert!(source.contains("fn write_run_with_hook("));
     }
 
     #[test]

--- a/src/status_kill.rs
+++ b/src/status_kill.rs
@@ -1,7 +1,7 @@
 //! Team status and teardown commands from `docs/spec.md` sections 6 and 12.
 
 use crate::herdr::{AgentInfo, HerdrApi, HerdrClient, HerdrError};
-use crate::run::{load_run, mark_ended, RunBoard, RunError};
+use crate::run::{load_run, update_run_with_hook, RunBoard, RunError};
 use crate::types::{RunLifecycle, WorkerLifecycle};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
@@ -375,7 +375,7 @@ fn kill_run_with_backend(
     let mut run = load_run(run_dir)?;
     if run.state.lifecycle == RunLifecycle::Ended {
         if end_worker_lifecycles(&mut run) {
-            mark_ended(&mut run)?;
+            persist_kill_state(run_dir, None, true)?;
         }
         return Ok(());
     }
@@ -419,8 +419,7 @@ fn kill_run_with_backend(
         }
     }
 
-    end_worker_lifecycles(&mut run);
-    mark_ended(&mut run)?;
+    persist_kill_state(run_dir, None, true)?;
     if dirty_paths.is_empty() {
         Ok(())
     } else {
@@ -434,7 +433,7 @@ fn kill_worker_with_backend(
     remove_worktrees: bool,
     backend: &impl TeardownBackend,
 ) -> Result<(), StatusKillError> {
-    let mut run = load_run(run_dir)?;
+    let run = load_run(run_dir)?;
     if run.state.lifecycle == RunLifecycle::Ended {
         return Ok(());
     }
@@ -482,26 +481,43 @@ fn kill_worker_with_backend(
     } else {
         WorkerLifecycle::Ended
     };
-    run.state
-        .workers
-        .get_mut(worker_name)
-        .expect("worker was loaded above")
-        .lifecycle = terminal;
-    if run.state.workers.values().all(|state| {
-        matches!(
-            state.lifecycle,
-            WorkerLifecycle::Ended | WorkerLifecycle::Released | WorkerLifecycle::Failed
-        )
-    }) {
-        mark_ended(&mut run)?;
-    } else {
-        crate::run::save_run(&run)?;
-    }
+    let ends_run = run.state.workers.iter().all(|(name, state)| {
+        name == worker_name
+            || matches!(
+                state.lifecycle,
+                WorkerLifecycle::Ended | WorkerLifecycle::Released | WorkerLifecycle::Failed
+            )
+    });
+    persist_kill_state(run_dir, Some((worker_name, terminal)), ends_run)?;
     if dirty_paths.is_empty() {
         Ok(())
     } else {
         Err(StatusKillError::DirtyWorktrees { paths: dirty_paths })
     }
+}
+
+fn persist_kill_state(
+    run_dir: &Path,
+    worker: Option<(&str, WorkerLifecycle)>,
+    end_run: bool,
+) -> Result<(), StatusKillError> {
+    update_run_with_hook(run_dir, |fresh, _| -> Result<(), StatusKillError> {
+        if let Some((name, lifecycle)) = worker {
+            fresh
+                .state
+                .workers
+                .get_mut(name)
+                .expect("kill target exists in persisted run state")
+                .lifecycle = lifecycle;
+        } else {
+            end_worker_lifecycles(fresh);
+        }
+        if end_run {
+            fresh.state.lifecycle = RunLifecycle::Ended;
+        }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 fn release_adopted_workers(run: &mut RunBoard, backend: &impl TeardownBackend) {
@@ -597,6 +613,7 @@ fn worktree_is_dirty(path: &Path) -> Result<bool, StatusKillError> {
 mod tests {
     use super::*;
     use crate::herdr::test_support::FakeHerdr;
+    use crate::run::mark_ended;
     use crate::run::{create_run, load_run, match_pane};
     use crate::types::{
         GodSpec, RunState, TeamSpec, Topology, WorkerLifecycle, WorkerRunState, WorkerSpec,
@@ -934,6 +951,29 @@ mod tests {
             WorkerLifecycle::Running
         );
         assert_eq!(backend.closed.into_inner(), ["workspace-builder"]);
+    }
+
+    #[test]
+    fn kill_worker_writer_preserves_fresher_hook_state() {
+        let temp = TempDir::new();
+        let run = create_run(temp.path(), run_state(temp.path())).unwrap();
+        crate::run::update_run_with_hook(&run.dir, |fresh, _| -> Result<(), StatusKillError> {
+            fresh.state.workers.get_mut("reviewer").unwrap().lifecycle = WorkerLifecycle::Orphaned;
+            Ok(())
+        })
+        .unwrap();
+
+        kill_worker_with_backend(&run.dir, "builder", false, &FakeTeardown::default()).unwrap();
+
+        let persisted = load_run(&run.dir).unwrap();
+        assert_eq!(
+            persisted.state.workers["builder"].lifecycle,
+            WorkerLifecycle::Ended
+        );
+        assert_eq!(
+            persisted.state.workers["reviewer"].lifecycle,
+            WorkerLifecycle::Orphaned
+        );
     }
 
     #[test]

--- a/src/status_kill.rs
+++ b/src/status_kill.rs
@@ -481,14 +481,7 @@ fn kill_worker_with_backend(
     } else {
         WorkerLifecycle::Ended
     };
-    let ends_run = run.state.workers.iter().all(|(name, state)| {
-        name == worker_name
-            || matches!(
-                state.lifecycle,
-                WorkerLifecycle::Ended | WorkerLifecycle::Released | WorkerLifecycle::Failed
-            )
-    });
-    persist_kill_state(run_dir, Some((worker_name, terminal)), ends_run)?;
+    persist_kill_state(run_dir, Some((worker_name, terminal)), false)?;
     if dirty_paths.is_empty() {
         Ok(())
     } else {
@@ -509,6 +502,14 @@ fn persist_kill_state(
                 .get_mut(name)
                 .expect("kill target exists in persisted run state")
                 .lifecycle = lifecycle;
+            if fresh.state.workers.values().all(|state| {
+                matches!(
+                    state.lifecycle,
+                    WorkerLifecycle::Ended | WorkerLifecycle::Released | WorkerLifecycle::Failed
+                )
+            }) {
+                fresh.state.lifecycle = RunLifecycle::Ended;
+            }
         } else {
             end_worker_lifecycles(fresh);
         }


### PR DESCRIPTION
## Summary
- route adopt, attention, and kill run-board mutations through the flocked fresh-load transaction
- make unlocked save helpers test-only so production writers cannot bypass the lock
- recover pending adopted workers by rerunning adopt without launching an agent CLI; healthy adoptees are a clear no-op
- document the transaction and recovery semantics

## Verification
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test (158 passed)
- 15 consecutive full cargo test runs

Closes #28. Closes #29.