### PR TITLE
feat: direct socket backend behind HerdrApi

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -274,9 +274,12 @@ feature.
    unsupported. Mutating `HerdrApi` calls always delegate to the CLI backend.
    Frames are capped at 1 MiB; reconnects have a fixed cap, backoff, and overall
    deadline; response IDs and typed result/event shapes are validated. Board and
-   aggregate wait bootstrap with `session.snapshot`, then use one multiplexed
-   `events.subscribe` connection for the durable run's worker pane IDs;
-   reconnect re-snapshots. Completion truth remains `run.toml` and inbox state.
+   aggregate wait bootstrap with `session.snapshot`, then retain one multiplexed
+   `events.subscribe` connection for the durable run's worker pane IDs across
+   refresh cycles. Ordinary read timeouts preserve that stream; transport loss
+   drops it, re-snapshots, and reconnects. An immediate subscription failure
+   spends only the remaining wait budget in bounded CLI polling. Completion
+   truth remains `run.toml` and inbox state.
    Set `HERDR_TEAM_SOCKET_TRACE=<path>` for redacted JSONL diagnostics (request
    ID, method, result type, latency, and a fixed error category only; server
    text is never written).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -268,12 +268,18 @@ feature.
 
    Selection is explicit: set `HERDR_TEAM_BACKEND=socket`. The adapter uses
    only the public NDJSON socket named by `HERDR_SOCKET_PATH`, validates a
-   protocol-16 `ping` handshake and the checked-in schema baseline, and falls
-   back cleanly to the CLI collector if the path is absent, connection fails,
-   or the handshake is unsupported. Mutating `HerdrApi` calls always delegate
-   to the CLI backend. Frames are capped at 1 MiB and response IDs/result
-   shapes are validated. Set `HERDR_TEAM_SOCKET_TRACE=<path>` for redacted
-   JSONL diagnostics (request ID, method, result type, latency, and error only).
+   protocol-16 `ping` handshake and requires `herdr api schema --json` to match
+   the checked-in schema baseline. It falls back cleanly if the path is absent,
+   an I/O deadline expires, runtime schema drifts, or the handshake is
+   unsupported. Mutating `HerdrApi` calls always delegate to the CLI backend.
+   Frames are capped at 1 MiB; reconnects have a fixed cap, backoff, and overall
+   deadline; response IDs and typed result/event shapes are validated. Board and
+   aggregate wait bootstrap with `session.snapshot`, then use one multiplexed
+   `events.subscribe` connection for the durable run's worker pane IDs;
+   reconnect re-snapshots. Completion truth remains `run.toml` and inbox state.
+   Set `HERDR_TEAM_SOCKET_TRACE=<path>` for redacted JSONL diagnostics (request
+   ID, method, result type, latency, and a fixed error category only; server
+   text is never written).
 8. **Bounded previews + conservative restart** (broadcast moved to the god
    toolkit):
    `team msg --all` loops run members with per-target results; board

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -265,6 +265,15 @@ feature.
 7. **Direct socket backend behind `HerdrApi`** (ADR-0011): `SocketClient`
    adapter; board + `team wait` collectors swap to snapshot/subscribe with
    no interface change; CLI stays default/fallback.
+
+   Selection is explicit: set `HERDR_TEAM_BACKEND=socket`. The adapter uses
+   only the public NDJSON socket named by `HERDR_SOCKET_PATH`, validates a
+   protocol-16 `ping` handshake and the checked-in schema baseline, and falls
+   back cleanly to the CLI collector if the path is absent, connection fails,
+   or the handshake is unsupported. Mutating `HerdrApi` calls always delegate
+   to the CLI backend. Frames are capped at 1 MiB and response IDs/result
+   shapes are validated. Set `HERDR_TEAM_SOCKET_TRACE=<path>` for redacted
+   JSONL diagnostics (request ID, method, result type, latency, and error only).
 8. **Bounded previews + conservative restart** (broadcast moved to the god
    toolkit):
    `team msg --all` loops run members with per-target results; board

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -277,9 +277,14 @@ feature.
    aggregate wait bootstrap with `session.snapshot`, then retain one multiplexed
    `events.subscribe` connection for the durable run's worker pane IDs across
    refresh cycles. Ordinary read timeouts preserve that stream; transport loss
-   drops it, re-snapshots, and reconnects. An immediate subscription failure
-   spends only the remaining wait budget in bounded CLI polling. Completion
-   truth remains `run.toml` and inbox state.
+   drops it and enters a capped, backed-off, overall-deadline reconnect state.
+   Every replacement subscription is gated on a successful fresh snapshot.
+   Protocol/typed-validation errors are terminal and never reconnect. An
+   immediate subscription failure spends only the remaining wait budget in
+   bounded CLI polling. One shared collector socket controller owns these
+   transitions for board and aggregate wait; their wrappers only map outcomes
+   to UI refresh versus CLI fallback. Completion truth remains `run.toml` and
+   inbox state.
    Set `HERDR_TEAM_SOCKET_TRACE=<path>` for redacted JSONL diagnostics (request
    ID, method, result type, latency, and a fixed error category only; server
    text is never written).

--- a/src/board.rs
+++ b/src/board.rs
@@ -187,7 +187,12 @@ pub fn render(snapshot: &BoardSnapshot, selection: usize) -> String {
 
 pub fn board_command(args: &[String]) -> Result<(), BoardError> {
     let run_dir = select_run(args)?;
-    run_board(RunCollector { run_dir })
+    let fallback = RunCollector { run_dir };
+    if let Some(socket) = crate::socket::SocketClient::try_from_env() {
+        run_board(crate::socket::SocketBoardCollector { socket, fallback })
+    } else {
+        run_board(fallback)
+    }
 }
 
 pub fn open_report_command(args: &[String]) -> Result<(), BoardError> {

--- a/src/board.rs
+++ b/src/board.rs
@@ -207,7 +207,9 @@ pub fn board_command(args: &[String]) -> Result<(), BoardError> {
     let run_dir = select_run(args)?;
     let fallback = RunCollector { run_dir };
     if let Some(socket) = crate::socket::SocketClient::try_from_env() {
-        run_board(crate::socket::SocketBoardCollector { socket, fallback })
+        run_board(crate::socket_backend::SocketBoardCollector::new(
+            socket, fallback,
+        ))
     } else {
         run_board(fallback)
     }

--- a/src/board.rs
+++ b/src/board.rs
@@ -53,6 +53,13 @@ pub struct BoardSnapshot {
 /// Collection stays behind this seam so socket snapshots can replace polling in #8.
 pub trait BoardCollector {
     fn collect(&self) -> Result<BoardSnapshot, BoardError>;
+    fn wait_for_change(&self, timeout: Duration) -> bool {
+        std::thread::sleep(timeout);
+        true
+    }
+    fn subscription_panes(&self) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 pub struct RunCollector {
@@ -62,6 +69,17 @@ pub struct RunCollector {
 impl BoardCollector for RunCollector {
     fn collect(&self) -> Result<BoardSnapshot, BoardError> {
         collect_run(&self.run_dir)
+    }
+    fn subscription_panes(&self) -> Vec<String> {
+        load_run(&self.run_dir)
+            .map(|run| {
+                run.state
+                    .workers
+                    .values()
+                    .filter_map(|worker| worker.pane_id.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 }
 
@@ -279,8 +297,10 @@ fn run_board(collector: impl BoardCollector) -> Result<(), BoardError> {
             )?;
             print!("{}", render(&snapshot, selection));
             stdout.flush()?;
-            if !event::poll(Duration::from_secs(2))? {
-                snapshot = collector.collect()?;
+            if !event::poll(Duration::from_millis(100))? {
+                if collector.wait_for_change(Duration::from_millis(100)) {
+                    snapshot = collector.collect()?;
+                }
                 continue;
             }
             let Event::Key(key) = event::read()? else {

--- a/src/god_cli.rs
+++ b/src/god_cli.rs
@@ -196,7 +196,9 @@ pub fn wait_command(args: &[String]) -> Result<WaitVerdict, GodCliError> {
     let run_dir = select_wait_run(run_dir.as_deref())?;
     let fallback = RunGodCollector { run_dir };
     let collector: Box<dyn GodCollector> = match crate::socket::SocketClient::try_from_env() {
-        Some(socket) => Box::new(crate::socket::SocketGodCollector { socket, fallback }),
+        Some(socket) => Box::new(crate::socket_backend::SocketGodCollector::new(
+            socket, fallback,
+        )),
         None => Box::new(fallback),
     };
     validate_until(&collector.collect()?, &until)?;

--- a/src/god_cli.rs
+++ b/src/god_cli.rs
@@ -61,6 +61,9 @@ pub struct GodSnapshot {
 /// Polling seam intentionally mirrors `BoardCollector`; #8 can replace it.
 pub trait GodCollector {
     fn collect(&self) -> Result<GodSnapshot, GodCliError>;
+    fn wait_for_change(&self, timeout: Duration) {
+        thread::sleep(timeout);
+    }
 }
 
 pub struct RunGodCollector {
@@ -177,9 +180,13 @@ pub fn report_command(args: &[String]) -> Result<(), GodCliError> {
 pub fn wait_command(args: &[String]) -> Result<WaitVerdict, GodCliError> {
     let (run_dir, until, timeout, json) = parse_wait(args)?;
     let run_dir = select_wait_run(run_dir.as_deref())?;
-    let collector = RunGodCollector { run_dir };
+    let fallback = RunGodCollector { run_dir };
+    let collector: Box<dyn GodCollector> = match crate::socket::SocketClient::try_from_env() {
+        Some(socket) => Box::new(crate::socket::SocketGodCollector { socket, fallback }),
+        None => Box::new(fallback),
+    };
     validate_until(&collector.collect()?, &until)?;
-    let verdict = wait_with(&collector, &until, timeout)?;
+    let verdict = wait_with(collector.as_ref(), &until, timeout)?;
     if json {
         println!("{}", serde_json::to_string(&verdict)?);
     } else {
@@ -189,7 +196,7 @@ pub fn wait_command(args: &[String]) -> Result<WaitVerdict, GodCliError> {
 }
 
 pub fn wait_with(
-    collector: &impl GodCollector,
+    collector: &(impl GodCollector + ?Sized),
     until: &Until,
     timeout: Duration,
 ) -> Result<WaitVerdict, GodCliError> {
@@ -208,7 +215,7 @@ pub fn wait_with(
         if start.elapsed() >= timeout {
             return Ok(verdict(VerdictKind::Timeout, until, None, start));
         }
-        thread::sleep(POLL_INTERVAL.min(timeout.saturating_sub(start.elapsed())));
+        collector.wait_for_change(POLL_INTERVAL.min(timeout.saturating_sub(start.elapsed())));
     }
 }
 

--- a/src/god_cli.rs
+++ b/src/god_cli.rs
@@ -64,6 +64,9 @@ pub trait GodCollector {
     fn wait_for_change(&self, timeout: Duration) {
         thread::sleep(timeout);
     }
+    fn subscription_panes(&self) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 pub struct RunGodCollector {
@@ -73,6 +76,17 @@ pub struct RunGodCollector {
 impl GodCollector for RunGodCollector {
     fn collect(&self) -> Result<GodSnapshot, GodCliError> {
         collect_snapshot(&self.run_dir)
+    }
+    fn subscription_panes(&self) -> Vec<String> {
+        load_run(&self.run_dir)
+            .map(|run| {
+                run.state
+                    .workers
+                    .values()
+                    .filter_map(|worker| worker.pane_id.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 }
 
@@ -201,7 +215,13 @@ pub fn wait_with(
     timeout: Duration,
 ) -> Result<WaitVerdict, GodCliError> {
     let start = Instant::now();
+    let deadline = start + timeout;
+    let mut first = true;
     loop {
+        if !first && Instant::now() >= deadline {
+            return Ok(verdict(VerdictKind::Timeout, until, None, start));
+        }
+        first = false;
         let snapshot = collector.collect()?;
         if snapshot.lifecycle != RunLifecycle::Active {
             return Ok(verdict(VerdictKind::InactiveRun, until, None, start));
@@ -212,10 +232,11 @@ pub fn wait_with(
         if condition_met(&snapshot, until) {
             return Ok(verdict(VerdictKind::Reached, until, None, start));
         }
-        if start.elapsed() >= timeout {
+        if Instant::now() >= deadline {
             return Ok(verdict(VerdictKind::Timeout, until, None, start));
         }
-        collector.wait_for_change(POLL_INTERVAL.min(timeout.saturating_sub(start.elapsed())));
+        collector
+            .wait_for_change(POLL_INTERVAL.min(deadline.saturating_duration_since(Instant::now())));
     }
 }
 
@@ -532,6 +553,23 @@ mod tests {
             worker_lifecycles: vec![("a".into(), life)],
             statuses: vec![("a".into(), status.into())],
         }
+    }
+    struct DeadlineCollector;
+    impl GodCollector for DeadlineCollector {
+        fn collect(&self) -> Result<GodSnapshot, GodCliError> {
+            Ok(snap(false, "working", WorkerLifecycle::Running))
+        }
+        fn wait_for_change(&self, timeout: Duration) {
+            std::thread::sleep(timeout);
+        }
+    }
+    #[test]
+    fn wait_preserves_total_deadline_without_second_fallback_sleep() {
+        let timeout = Duration::from_millis(40);
+        let started = Instant::now();
+        let verdict = wait_with(&DeadlineCollector, &Until::AnyReport, timeout).unwrap();
+        assert_eq!(verdict.verdict, VerdictKind::Timeout);
+        assert!(started.elapsed() < Duration::from_millis(80));
     }
     #[test]
     fn every_until_mode_resolves() {

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -10,6 +10,13 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum HerdrError {
+    #[error("public socket {operation} failed: {source}")]
+    Transport {
+        operation: String,
+        #[source]
+        source: std::io::Error,
+    },
+
     #[error("failed to spawn `{argv}`: {source}")]
     Spawn {
         argv: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ pub mod paths;
 pub mod reconcile;
 pub mod run;
 pub mod socket;
+pub mod socket_backend;
 pub mod spawn;
 pub mod spec;
 pub mod status_kill;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ pub mod msg;
 pub mod paths;
 pub mod reconcile;
 pub mod run;
+pub mod socket;
 pub mod spawn;
 pub mod spec;
 pub mod status_kill;

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -3,12 +3,7 @@
 //! Mutations deliberately delegate to the CLI. The socket is reserved for
 //! snapshots and multiplexed event subscriptions.
 
-use crate::board::{BoardCollector, BoardError, BoardSnapshot};
-use crate::god_cli::{GodCliError, GodCollector, GodSnapshot};
-use crate::herdr::{
-    AgentInfo, HerdrApi, HerdrClient, HerdrError, PaneInfo, WaitOutcome, WorkspaceRef, WorktreeRef,
-};
-use crate::metadata::MetadataUpdate;
+use crate::herdr::{HerdrApi, HerdrClient, HerdrError};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::fs::OpenOptions;
@@ -146,21 +141,6 @@ impl SocketClient<HerdrClient> {
         let path = std::env::var_os("HERDR_SOCKET_PATH").map(PathBuf::from)?;
         Self::connect(path, HerdrClient::from_env()).ok()
     }
-    /// Opt in with `HERDR_TEAM_BACKEND=socket`; any handshake failure returns
-    /// the ordinary CLI client, preserving the pre-ADR behavior.
-    pub fn from_env_or_cli() -> Backend {
-        let cli = HerdrClient::from_env();
-        if std::env::var(BACKEND_ENV).as_deref() != Ok("socket") {
-            return Backend::Cli(cli);
-        }
-        let Some(path) = std::env::var_os("HERDR_SOCKET_PATH").map(PathBuf::from) else {
-            return Backend::Cli(cli);
-        };
-        match Self::connect(path, cli.clone()) {
-            Ok(socket) => Backend::Socket(socket),
-            Err(_) => Backend::Cli(cli),
-        }
-    }
 }
 
 impl<C: HerdrApi> SocketClient<C> {
@@ -265,6 +245,22 @@ impl<C: HerdrApi> SocketClient<C> {
     ) -> Result<bool, HerdrError> {
         self.read_one_event(subscriptions, timeout)
             .map(|event| event.is_some())
+    }
+
+    pub(crate) fn subscribe(
+        &self,
+        subscriptions: &[Value],
+        timeout: Duration,
+    ) -> Result<SubscriptionStream, HerdrError> {
+        self.open_subscription(subscriptions, timeout)
+            .map(|reader| SubscriptionStream {
+                reader,
+                max_frame_bytes: self.max_frame_bytes,
+            })
+    }
+
+    pub(crate) fn fallback(&self) -> &C {
+        &self.fallback
     }
 
     fn read_one_event(
@@ -376,150 +372,50 @@ impl<C: HerdrApi> SocketClient<C> {
     }
 }
 
+pub(crate) struct SubscriptionStream {
+    reader: BufReader<UnixStream>,
+    max_frame_bytes: usize,
+}
+
+pub(crate) enum SubscriptionPoll {
+    Event(SubscriptionEvent),
+    Timeout,
+    Closed,
+}
+
+impl SubscriptionStream {
+    pub(crate) fn poll(&mut self, timeout: Duration) -> Result<SubscriptionPoll, HerdrError> {
+        self.reader
+            .get_ref()
+            .set_read_timeout(Some(timeout))
+            .map_err(|source| transport("set subscription timeout", source))?;
+        match read_value_optional(&mut self.reader, self.max_frame_bytes, "events.subscribe") {
+            Ok(Some(value)) => serde_json::from_value(value)
+                .map(SubscriptionPoll::Event)
+                .map_err(|e| invalid("events.subscribe event", e)),
+            Ok(None) => Ok(SubscriptionPoll::Closed),
+            Err(HerdrError::Transport { source, .. })
+                if matches!(
+                    source.kind(),
+                    std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+                ) =>
+            {
+                Ok(SubscriptionPoll::Timeout)
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum StreamItem {
     Snapshot(SessionSnapshot),
     Event(SubscriptionEvent),
 }
 
-pub enum Backend {
-    Cli(HerdrClient),
-    Socket(SocketClient),
-}
-
-/// Socket-aware collector adapters preserve durable run/inbox truth. A socket
-/// snapshot is used as the fast freshness probe; clean fallback retains the
-/// exact existing collector verdict when the socket disappears.
-pub struct SocketGodCollector<C, G> {
-    pub socket: SocketClient<C>,
-    pub fallback: G,
-}
-impl<C: HerdrApi, G: GodCollector> GodCollector for SocketGodCollector<C, G> {
-    fn collect(&self) -> Result<GodSnapshot, GodCliError> {
-        let _ = self.socket.snapshot();
-        self.fallback.collect()
-    }
-    fn wait_for_change(&self, timeout: Duration) {
-        let subscriptions = self
-            .fallback
-            .subscription_panes()
-            .into_iter()
-            .map(|pane_id| json!({"type":"pane.agent_status_changed","pane_id":pane_id}))
-            .collect::<Vec<_>>();
-        if subscriptions.is_empty() {
-            self.fallback.wait_for_change(timeout);
-        } else {
-            let _ = self.socket.wait_for_change(&subscriptions, timeout);
-        }
-    }
-    fn subscription_panes(&self) -> Vec<String> {
-        self.fallback.subscription_panes()
-    }
-}
-pub struct SocketBoardCollector<C, B> {
-    pub socket: SocketClient<C>,
-    pub fallback: B,
-}
-impl<C: HerdrApi, B: BoardCollector> BoardCollector for SocketBoardCollector<C, B> {
-    fn collect(&self) -> Result<BoardSnapshot, BoardError> {
-        let _ = self.socket.snapshot();
-        self.fallback.collect()
-    }
-    fn wait_for_change(&self, timeout: Duration) -> bool {
-        let subscriptions = self
-            .fallback
-            .subscription_panes()
-            .into_iter()
-            .map(|pane_id| json!({"type":"pane.agent_status_changed","pane_id":pane_id}))
-            .collect::<Vec<_>>();
-        self.socket
-            .wait_for_change(&subscriptions, timeout)
-            .unwrap_or(true)
-    }
-    fn subscription_panes(&self) -> Vec<String> {
-        self.fallback.subscription_panes()
-    }
-}
-
-macro_rules! delegate {
-    ($self:ident.$method:ident($($arg:expr),*)) => { match $self { Backend::Cli(c) => c.$method($($arg),*), Backend::Socket(c) => c.$method($($arg),*) } };
-}
-
-impl HerdrApi for Backend {
-    fn workspace_create(&self, c: &Path, l: &str) -> Result<WorkspaceRef, HerdrError> {
-        delegate!(self.workspace_create(c, l))
-    }
-    fn workspace_close(&self, w: &str) -> Result<(), HerdrError> {
-        delegate!(self.workspace_close(w))
-    }
-    fn worktree_create(&self, r: &Path, b: &str) -> Result<WorktreeRef, HerdrError> {
-        delegate!(self.worktree_create(r, b))
-    }
-    fn worktree_remove(&self, p: &Path) -> Result<(), HerdrError> {
-        delegate!(self.worktree_remove(p))
-    }
-    fn pane_run(&self, p: &str, i: &str) -> Result<(), HerdrError> {
-        delegate!(self.pane_run(p, i))
-    }
-    fn pane_get(&self, p: &str) -> Result<PaneInfo, HerdrError> {
-        delegate!(self.pane_get(p))
-    }
-    fn agent_list(&self) -> Result<Vec<AgentInfo>, HerdrError> {
-        delegate!(self.agent_list())
-    }
-    fn agent_wait(&self, p: &str, s: &str, t: Duration) -> Result<WaitOutcome, HerdrError> {
-        delegate!(self.agent_wait(p, s, t))
-    }
-}
-
-impl<C: HerdrApi> HerdrApi for SocketClient<C> {
-    fn workspace_create(&self, c: &Path, l: &str) -> Result<WorkspaceRef, HerdrError> {
-        self.fallback.workspace_create(c, l)
-    }
-    fn workspace_close(&self, w: &str) -> Result<(), HerdrError> {
-        self.fallback.workspace_close(w)
-    }
-    fn worktree_create(&self, r: &Path, b: &str) -> Result<WorktreeRef, HerdrError> {
-        self.fallback.worktree_create(r, b)
-    }
-    fn worktree_remove(&self, p: &Path) -> Result<(), HerdrError> {
-        self.fallback.worktree_remove(p)
-    }
-    fn pane_split(&self, w: &str, c: &Path) -> Result<PaneInfo, HerdrError> {
-        self.fallback.pane_split(w, c)
-    }
-    fn pane_run(&self, p: &str, i: &str) -> Result<(), HerdrError> {
-        self.fallback.pane_run(p, i)
-    }
-    fn pane_read(&self, p: &str) -> Result<String, HerdrError> {
-        self.fallback.pane_read(p)
-    }
-    fn pane_rename(&self, p: &str, t: &str) -> Result<(), HerdrError> {
-        self.fallback.pane_rename(p, t)
-    }
-    fn agent_wait(&self, p: &str, s: &str, t: Duration) -> Result<WaitOutcome, HerdrError> {
-        self.fallback.agent_wait(p, s, t)
-    }
-    fn agent_list(&self) -> Result<Vec<AgentInfo>, HerdrError> {
-        self.fallback.agent_list()
-    }
-    fn pane_get(&self, p: &str) -> Result<PaneInfo, HerdrError> {
-        self.fallback.pane_get(p)
-    }
-    fn api_schema(&self) -> Result<String, HerdrError> {
-        self.fallback.api_schema()
-    }
-    fn pane_report_metadata(&self, p: &str, u: &MetadataUpdate) -> Result<(), HerdrError> {
-        self.fallback.pane_report_metadata(p, u)
-    }
-    fn notification_show(&self, t: &str, b: &str, s: &str) -> Result<(), HerdrError> {
-        self.fallback.notification_show(t, b, s)
-    }
-}
-
 #[cfg(unix)]
 fn connect(path: &Path) -> Result<UnixStream, HerdrError> {
-    UnixStream::connect(path).map_err(|e| invalid_msg("socket connect", &e.to_string()))
+    UnixStream::connect(path).map_err(|source| transport("connect", source))
 }
 #[cfg(not(unix))]
 fn connect(_: &Path) -> Result<std::fs::File, HerdrError> {
@@ -530,8 +426,10 @@ fn connect(_: &Path) -> Result<std::fs::File, HerdrError> {
 }
 fn write_request<W: Write>(w: &mut W, r: &Request<'_>) -> Result<(), HerdrError> {
     serde_json::to_writer(&mut *w, r).map_err(|e| invalid("request", e))?;
-    w.write_all(b"\n").map_err(|e| invalid("request", e))?;
-    w.flush().map_err(|e| invalid("request", e))
+    w.write_all(b"\n")
+        .map_err(|source| transport("write request", source))?;
+    w.flush()
+        .map_err(|source| transport("flush request", source))
 }
 fn read_envelope<R: BufRead>(r: &mut R, max: usize, m: &str) -> Result<Envelope, HerdrError> {
     let v = read_value_optional(r, max, m)?.ok_or_else(|| invalid_msg(m, "empty response"))?;
@@ -546,7 +444,7 @@ fn read_value_optional<R: BufRead>(
     let mut limited = std::io::Read::take(std::io::Read::by_ref(r), (max + 1) as u64);
     let n = limited
         .read_until(b'\n', &mut bytes)
-        .map_err(|e| invalid(m, e))?;
+        .map_err(|source| transport(&format!("read {m}"), source))?;
     if n == 0 {
         return Ok(None);
     }
@@ -587,6 +485,12 @@ fn invalid_msg(m: &str, s: &str) -> HerdrError {
     HerdrError::InvalidResponse {
         argv: format!("public socket {m}"),
         message: s.into(),
+    }
+}
+fn transport(operation: &str, source: std::io::Error) -> HerdrError {
+    HerdrError::Transport {
+        operation: operation.to_owned(),
+        source,
     }
 }
 fn validate_runtime_schema(runtime: &str) -> Result<(), HerdrError> {
@@ -632,9 +536,10 @@ fn write_trace(path: &Path, row: &Value) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::board::{BoardSnapshot, BoardWorker};
-    use crate::god_cli::{GodSnapshot, InboxRow};
+    use crate::board::{BoardCollector, BoardError, BoardSnapshot, BoardWorker};
+    use crate::god_cli::{GodCliError, GodCollector, GodSnapshot, InboxRow};
     use crate::herdr::test_support::FakeHerdr;
+    use crate::socket_backend::{SocketBoardCollector, SocketGodCollector};
     use crate::types::{RunLifecycle, WorkerLifecycle};
     use std::fs;
     use std::os::unix::net::UnixListener;
@@ -693,6 +598,51 @@ mod tests {
                     .push(serde_json::from_str(&line).unwrap());
                 stream.write_all(response.as_bytes()).unwrap();
             }
+        });
+        (path, h, requests)
+    }
+    fn persistent_board_fake() -> (
+        PathBuf,
+        thread::JoinHandle<()>,
+        std::sync::Arc<std::sync::Mutex<Vec<Value>>>,
+    ) {
+        let path = std::env::temp_dir().join(format!(
+            "hat-persistent-{}-{}.sock",
+            std::process::id(),
+            rand_id()
+        ));
+        let _ = fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+        let requests = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = requests.clone();
+        let h = thread::spawn(move || {
+            for response in [
+                pong("herdr-agent-team:0", 16),
+                snapshot("herdr-agent-team:1"),
+            ] {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut line = String::new();
+                BufReader::new(stream.try_clone().unwrap())
+                    .read_line(&mut line)
+                    .unwrap();
+                captured
+                    .lock()
+                    .unwrap()
+                    .push(serde_json::from_str(&line).unwrap());
+                stream.write_all(response.as_bytes()).unwrap();
+            }
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut line = String::new();
+            BufReader::new(stream.try_clone().unwrap())
+                .read_line(&mut line)
+                .unwrap();
+            captured
+                .lock()
+                .unwrap()
+                .push(serde_json::from_str(&line).unwrap());
+            stream.write_all(b"{\"id\":\"herdr-agent-team:2\",\"result\":{\"type\":\"subscription_started\"}}\n").unwrap();
+            thread::sleep(Duration::from_millis(30));
+            let _ = stream.write_all(b"{\"event\":\"pane.agent_status_changed\",\"data\":{\"pane_id\":\"p1\",\"workspace_id\":\"w1\",\"agent_status\":\"blocked\"}}\n");
         });
         (path, h, requests)
     }
@@ -886,10 +836,7 @@ mod tests {
         ]);
         let socket = SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
         let cli = FixtureGod(expected.clone());
-        let over_socket = SocketGodCollector {
-            socket,
-            fallback: cli.clone(),
-        };
+        let over_socket = SocketGodCollector::new(socket, cli.clone());
         assert_eq!(cli.collect().unwrap(), over_socket.collect().unwrap());
         h.join().unwrap();
         let _ = fs::remove_file(path);
@@ -1010,10 +957,7 @@ mod tests {
             }],
             mailbox_events: 0,
         };
-        let collector = SocketBoardCollector {
-            socket,
-            fallback: FixtureBoard(durable.clone()),
-        };
+        let collector = SocketBoardCollector::new(socket, FixtureBoard(durable.clone()));
         assert_eq!(collector.collect().unwrap(), durable);
         assert!(collector.wait_for_change(Duration::from_millis(50)));
         h.join().unwrap();
@@ -1032,5 +976,97 @@ mod tests {
             "p1"
         );
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn board_preserves_one_subscription_across_refresh_polls() {
+        let (path, h, requests) = persistent_board_fake();
+        let socket = SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
+        let durable = BoardSnapshot {
+            team: "wave8".into(),
+            run_dir: "/run".into(),
+            lifecycle: "active".into(),
+            workers: vec![BoardWorker {
+                name: "m".into(),
+                lifecycle: WorkerLifecycle::Running,
+                pane_id: Some("p1".into()),
+                task: None,
+                report: None,
+            }],
+            mailbox_events: 0,
+        };
+        let collector = SocketBoardCollector::new(socket, FixtureBoard(durable));
+        collector.collect().unwrap();
+        assert!(!collector.wait_for_change(Duration::from_millis(5)));
+        assert!(collector.wait_for_change(Duration::from_millis(80)));
+        h.join().unwrap();
+        let methods = requests
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|request| request["method"].as_str().unwrap().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            methods,
+            vec!["ping", "session.snapshot", "events.subscribe"]
+        );
+        let _ = fs::remove_file(path);
+    }
+
+    #[derive(Clone)]
+    struct CountingGod {
+        waits: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+    impl GodCollector for CountingGod {
+        fn collect(&self) -> Result<GodSnapshot, GodCliError> {
+            Ok(FixtureGod(GodSnapshot {
+                run_dir: "/run".into(),
+                lifecycle: RunLifecycle::Active,
+                rows: vec![],
+                worker_lifecycles: vec![],
+                statuses: vec![],
+            })
+            .0)
+        }
+        fn wait_for_change(&self, timeout: Duration) {
+            self.waits.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            thread::sleep(timeout)
+        }
+        fn subscription_panes(&self) -> Vec<String> {
+            vec!["p1".into()]
+        }
+    }
+
+    #[test]
+    fn immediate_subscription_error_uses_one_bounded_cli_fallback_sleep() {
+        let error="{\"id\":\"herdr-agent-team:1\",\"error\":{\"code\":\"unsupported\",\"message\":\"no subscription\"}}\n";
+        let (path, h) = fake(vec![pong("herdr-agent-team:0", 16), error.into()]);
+        let socket = SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
+        let waits = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let collector = SocketGodCollector::new(
+            socket,
+            CountingGod {
+                waits: waits.clone(),
+            },
+        );
+        let started = Instant::now();
+        collector.wait_for_change(Duration::from_millis(20));
+        assert_eq!(waits.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert!(started.elapsed() >= Duration::from_millis(20));
+        assert!(started.elapsed() < Duration::from_millis(50));
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn transport_module_has_no_collector_adapter_dependencies() {
+        let source = include_str!("socket.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .unwrap();
+        assert!(!source.contains(&["crate", "::board"].concat()));
+        assert!(!source.contains(&["crate", "::god_cli"].concat()));
+        assert!(!source.contains(&["impl Board", "Collector"].concat()));
+        assert!(!source.contains(&["impl God", "Collector"].concat()));
     }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -129,6 +129,7 @@ pub struct SocketClient<C = HerdrClient> {
     fallback: C,
     max_frame_bytes: usize,
     io_timeout: Duration,
+    trace_path: Option<PathBuf>,
     next_id: std::sync::Arc<AtomicU64>,
     handshake: Handshake,
 }
@@ -155,6 +156,7 @@ impl<C: HerdrApi> SocketClient<C> {
             fallback,
             max_frame_bytes: DEFAULT_MAX_FRAME_BYTES,
             io_timeout: DEFAULT_IO_TIMEOUT,
+            trace_path: std::env::var_os(TRACE_ENV).map(PathBuf::from),
             next_id: Default::default(),
             handshake: Handshake {
                 version: String::new(),
@@ -315,7 +317,7 @@ impl<C: HerdrApi> SocketClient<C> {
         let envelope = read_envelope(&mut BufReader::new(stream), self.max_frame_bytes, method)?;
         check_id(&id, &envelope.id, method)?;
         let outcome = result_or_error(envelope, method);
-        trace(
+        self.trace(
             method,
             &id,
             outcome.as_ref().ok(),
@@ -348,27 +350,72 @@ impl<C: HerdrApi> SocketClient<C> {
         subscriptions: &[Value],
         timeout: Duration,
     ) -> Result<BufReader<UnixStream>, HerdrError> {
+        let started = Instant::now();
         let id = self.request_id();
-        let mut stream = self.open_stream(timeout)?;
-        write_request(
-            &mut stream,
-            &Request {
-                id: &id,
-                method: "events.subscribe",
-                params: json!({"subscriptions": subscriptions}),
-            },
-        )?;
-        let mut reader = BufReader::new(stream);
-        let ack = read_envelope(&mut reader, self.max_frame_bytes, "events.subscribe")?;
-        check_id(&id, &ack.id, "events.subscribe")?;
-        let value = result_or_error(ack, "events.subscribe")?;
-        #[derive(Deserialize)]
-        #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
-        enum Ack {
-            SubscriptionStarted {},
+        let outcome = (|| {
+            let mut stream = self.open_stream(timeout)?;
+            write_request(
+                &mut stream,
+                &Request {
+                    id: &id,
+                    method: "events.subscribe",
+                    params: json!({"subscriptions": subscriptions}),
+                },
+            )?;
+            let mut reader = BufReader::new(stream);
+            let ack = read_envelope(&mut reader, self.max_frame_bytes, "events.subscribe")?;
+            check_id(&id, &ack.id, "events.subscribe")?;
+            let value = result_or_error(ack, "events.subscribe")?;
+            #[derive(Deserialize)]
+            #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+            enum Ack {
+                SubscriptionStarted {},
+            }
+            serde_json::from_value::<Ack>(value.clone())
+                .map_err(|e| invalid("events.subscribe ack", e))?;
+            Ok((reader, value))
+        })();
+        match outcome {
+            Ok((reader, value)) => {
+                self.trace(
+                    "events.subscribe",
+                    &id,
+                    Some(&value),
+                    None,
+                    started.elapsed(),
+                );
+                Ok(reader)
+            }
+            Err(error) => {
+                self.trace(
+                    "events.subscribe",
+                    &id,
+                    None,
+                    Some(&error),
+                    started.elapsed(),
+                );
+                Err(error)
+            }
         }
-        serde_json::from_value::<Ack>(value).map_err(|e| invalid("events.subscribe ack", e))?;
-        Ok(reader)
+    }
+
+    fn trace(
+        &self,
+        method: &str,
+        id: &str,
+        result: Option<&Value>,
+        error: Option<&HerdrError>,
+        elapsed: Duration,
+    ) {
+        let Some(path) = self.trace_path.as_deref() else {
+            return;
+        };
+        let result_type = result
+            .and_then(|value| value.get("type"))
+            .and_then(Value::as_str);
+        let error_code = error.map(|_| "transport_or_protocol_error");
+        let row = json!({"id":id,"method":method,"result_type":result_type,"error_code":error_code,"latency_ms":elapsed.as_millis()});
+        write_trace(path, &row);
     }
 }
 
@@ -511,21 +558,6 @@ fn validate_runtime_schema(runtime: &str) -> Result<(), HerdrError> {
         ));
     }
     Ok(())
-}
-fn trace(
-    method: &str,
-    id: &str,
-    result: Option<&Value>,
-    error: Option<&HerdrError>,
-    elapsed: Duration,
-) {
-    let Some(path) = std::env::var_os(TRACE_ENV) else {
-        return;
-    };
-    let result_type = result.and_then(|v| v.get("type")).and_then(Value::as_str);
-    let error_code = error.map(|_| "transport_or_protocol_error");
-    let row = json!({"id":id,"method":method,"result_type":result_type,"error_code":error_code,"latency_ms":elapsed.as_millis()});
-    write_trace(Path::new(&path), &row);
 }
 fn write_trace(path: &Path, row: &Value) {
     if let Ok(mut f) = OpenOptions::new().create(true).append(true).open(path) {
@@ -1201,5 +1233,56 @@ mod tests {
         );
         assert_eq!(source.matches("snapshot_pending").count(), 0);
         assert!(!source.contains("struct CollectorSocketState"));
+    }
+
+    #[test]
+    fn subscription_ack_and_error_are_traced_without_server_text() {
+        let trace_path =
+            std::env::temp_dir().join(format!("hat-subscription-trace-{}.jsonl", rand_id()));
+        let success =
+            "{\"id\":\"herdr-agent-team:1\",\"result\":{\"type\":\"subscription_started\"}}\n";
+        let (path, h) = fake(vec![pong("herdr-agent-team:0", 16), success.into()]);
+        let mut client =
+            SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
+        client.trace_path = Some(trace_path.clone());
+        drop(
+            client
+                .subscribe(
+                    &[json!({"type":"pane.agent_status_changed","pane_id":"p1"})],
+                    Duration::from_millis(20),
+                )
+                .unwrap(),
+        );
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+
+        let failure="{\"id\":\"herdr-agent-team:1\",\"error\":{\"code\":\"denied\",\"message\":\"SECRET prompt contents\"}}\n";
+        let (path, h) = fake(vec![pong("herdr-agent-team:0", 16), failure.into()]);
+        let mut client =
+            SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
+        client.trace_path = Some(trace_path.clone());
+        assert!(client
+            .subscribe(
+                &[json!({"type":"pane.agent_status_changed","pane_id":"p1"})],
+                Duration::from_millis(20)
+            )
+            .is_err());
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+        let rows = fs::read_to_string(&trace_path)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).unwrap())
+            .filter(|row| row["method"] == "events.subscribe")
+            .collect::<Vec<_>>();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["result_type"], "subscription_started");
+        assert!(rows[0]["error_code"].is_null());
+        assert_eq!(rows[1]["error_code"], "transport_or_protocol_error");
+        assert!(rows[1]["result_type"].is_null());
+        let contents = fs::read_to_string(&trace_path).unwrap();
+        assert!(!contents.contains("SECRET"));
+        assert!(!contents.contains("prompt contents"));
+        let _ = fs::remove_file(trace_path);
     }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,0 +1,713 @@
+//! Experimental protocol-16 public NDJSON socket backend (ADR-0011).
+//!
+//! Mutations deliberately delegate to the CLI. The socket is reserved for
+//! snapshots and multiplexed event subscriptions.
+
+use crate::board::{BoardCollector, BoardError, BoardSnapshot};
+use crate::god_cli::{GodCliError, GodCollector, GodSnapshot};
+use crate::herdr::{
+    AgentInfo, HerdrApi, HerdrClient, HerdrError, PaneInfo, WaitOutcome, WorkspaceRef, WorktreeRef,
+};
+use crate::metadata::MetadataUpdate;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Write};
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+pub const SUPPORTED_PROTOCOL: u32 = 16;
+pub const DEFAULT_MAX_FRAME_BYTES: usize = 1024 * 1024;
+const BACKEND_ENV: &str = "HERDR_TEAM_BACKEND";
+const TRACE_ENV: &str = "HERDR_TEAM_SOCKET_TRACE";
+const SCHEMA_BASELINE: &str = include_str!("../docs/herdr-api-schema.snapshot.json");
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Handshake {
+    pub version: String,
+    pub protocol: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SessionSnapshot {
+    pub version: String,
+    pub protocol: u32,
+    pub focused_workspace_id: Option<String>,
+    pub focused_tab_id: Option<String>,
+    pub focused_pane_id: Option<String>,
+    pub workspaces: Vec<Value>,
+    pub tabs: Vec<Value>,
+    pub panes: Vec<Value>,
+    pub layouts: Vec<Value>,
+    pub agents: Vec<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubscriptionEvent {
+    pub event: String,
+    pub data: Value,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Envelope {
+    id: String,
+    #[serde(default)]
+    result: Option<Value>,
+    #[serde(default)]
+    error: Option<ApiError>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ApiError {
+    code: String,
+    message: String,
+}
+
+#[derive(Debug, Serialize)]
+struct Request<'a> {
+    id: &'a str,
+    method: &'a str,
+    params: Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct SocketClient<C = HerdrClient> {
+    socket_path: PathBuf,
+    fallback: C,
+    max_frame_bytes: usize,
+    next_id: std::sync::Arc<AtomicU64>,
+    handshake: Handshake,
+}
+
+impl SocketClient<HerdrClient> {
+    pub fn try_from_env() -> Option<Self> {
+        if std::env::var(BACKEND_ENV).as_deref() != Ok("socket") {
+            return None;
+        }
+        let path = std::env::var_os("HERDR_SOCKET_PATH").map(PathBuf::from)?;
+        Self::connect(path, HerdrClient::from_env()).ok()
+    }
+    /// Opt in with `HERDR_TEAM_BACKEND=socket`; any handshake failure returns
+    /// the ordinary CLI client, preserving the pre-ADR behavior.
+    pub fn from_env_or_cli() -> Backend {
+        let cli = HerdrClient::from_env();
+        if std::env::var(BACKEND_ENV).as_deref() != Ok("socket") {
+            return Backend::Cli(cli);
+        }
+        let Some(path) = std::env::var_os("HERDR_SOCKET_PATH").map(PathBuf::from) else {
+            return Backend::Cli(cli);
+        };
+        match Self::connect(path, cli.clone()) {
+            Ok(socket) => Backend::Socket(socket),
+            Err(_) => Backend::Cli(cli),
+        }
+    }
+}
+
+impl<C: HerdrApi> SocketClient<C> {
+    pub fn connect(socket_path: PathBuf, fallback: C) -> Result<Self, HerdrError> {
+        validate_schema_baseline()?;
+        let mut client = Self {
+            socket_path,
+            fallback,
+            max_frame_bytes: DEFAULT_MAX_FRAME_BYTES,
+            next_id: Default::default(),
+            handshake: Handshake {
+                version: String::new(),
+                protocol: 0,
+            },
+        };
+        client.handshake = client.perform_handshake()?;
+        Ok(client)
+    }
+
+    pub fn handshake(&self) -> &Handshake {
+        &self.handshake
+    }
+
+    pub fn snapshot(&self) -> Result<SessionSnapshot, HerdrError> {
+        let result = self.rpc("session.snapshot", json!({}))?;
+        #[derive(Deserialize)]
+        #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+        enum ResultShape {
+            SessionSnapshot { snapshot: SessionSnapshot },
+        }
+        match serde_json::from_value::<ResultShape>(result)
+            .map_err(|e| invalid("session.snapshot", e))?
+        {
+            ResultShape::SessionSnapshot { snapshot } => Ok(snapshot),
+        }
+    }
+
+    /// Re-snapshots before every subscription attempt. EOF triggers a bounded
+    /// reconnect; callers receive each fresh snapshot before subsequent events.
+    pub fn subscribe_with_reconnect<F>(
+        &self,
+        subscriptions: &[Value],
+        reconnects: usize,
+        mut on_item: F,
+    ) -> Result<(), HerdrError>
+    where
+        F: FnMut(StreamItem),
+    {
+        for attempt in 0..=reconnects {
+            on_item(StreamItem::Snapshot(self.snapshot()?));
+            let id = self.request_id();
+            let mut stream = connect(&self.socket_path)?;
+            write_request(
+                &mut stream,
+                &Request {
+                    id: &id,
+                    method: "events.subscribe",
+                    params: json!({"subscriptions": subscriptions}),
+                },
+            )?;
+            let mut reader = BufReader::new(stream);
+            let ack = read_envelope(&mut reader, self.max_frame_bytes, "events.subscribe")?;
+            check_id(&id, &ack.id, "events.subscribe")?;
+            let value = result_or_error(ack, "events.subscribe")?;
+            if value.get("type").and_then(Value::as_str) != Some("subscription_started") {
+                return Err(invalid_msg(
+                    "events.subscribe",
+                    "expected result.type subscription_started",
+                ));
+            }
+            while let Some(value) =
+                read_value_optional(&mut reader, self.max_frame_bytes, "events.subscribe")?
+            {
+                on_item(StreamItem::Event(
+                    serde_json::from_value(value)
+                        .map_err(|e| invalid("events.subscribe event", e))?,
+                ));
+            }
+            if attempt == reconnects {
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
+
+    /// Wait for one event from a single subscription carrying every pane's
+    /// status changes. Team membership is filtered against durable run state
+    /// by `GodCollector`, so this stays one multiplexed server subscription.
+    pub fn wait_for_team_change(
+        &self,
+        timeout: Duration,
+    ) -> Result<Option<SubscriptionEvent>, HerdrError> {
+        let id = self.request_id();
+        let mut stream = connect(&self.socket_path)?;
+        stream
+            .set_read_timeout(Some(timeout))
+            .map_err(|e| invalid("events.subscribe", e))?;
+        write_request(
+            &mut stream,
+            &Request {
+                id: &id,
+                method: "events.subscribe",
+                params: json!({"subscriptions":[{"type":"pane.agent_status_changed"}]}),
+            },
+        )?;
+        let mut reader = BufReader::new(stream);
+        let ack = read_envelope(&mut reader, self.max_frame_bytes, "events.subscribe")?;
+        check_id(&id, &ack.id, "events.subscribe")?;
+        let value = result_or_error(ack, "events.subscribe")?;
+        if value.get("type").and_then(Value::as_str) != Some("subscription_started") {
+            return Err(invalid_msg(
+                "events.subscribe",
+                "expected result.type subscription_started",
+            ));
+        }
+        read_value_optional(&mut reader, self.max_frame_bytes, "events.subscribe")?
+            .map(|value| {
+                serde_json::from_value(value).map_err(|e| invalid("events.subscribe event", e))
+            })
+            .transpose()
+    }
+
+    fn perform_handshake(&self) -> Result<Handshake, HerdrError> {
+        let result = self.rpc("ping", json!({}))?;
+        #[derive(Deserialize)]
+        #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+        enum Pong {
+            Pong {
+                version: String,
+                protocol: u32,
+                #[serde(default)]
+                #[serde(rename = "capabilities")]
+                _capabilities: Option<Value>,
+            },
+        }
+        let Pong::Pong {
+            version,
+            protocol,
+            _capabilities: _,
+        } = serde_json::from_value(result).map_err(|e| invalid("ping", e))?;
+        if protocol != SUPPORTED_PROTOCOL {
+            return Err(invalid_msg("ping", &format!("unsupported Herdr protocol: client supports {SUPPORTED_PROTOCOL}, server reported {protocol} (version {version})")));
+        }
+        Ok(Handshake { version, protocol })
+    }
+
+    fn rpc(&self, method: &str, params: Value) -> Result<Value, HerdrError> {
+        let started = Instant::now();
+        let id = self.request_id();
+        let mut stream = connect(&self.socket_path)?;
+        write_request(
+            &mut stream,
+            &Request {
+                id: &id,
+                method,
+                params,
+            },
+        )?;
+        let envelope = read_envelope(&mut BufReader::new(stream), self.max_frame_bytes, method)?;
+        check_id(&id, &envelope.id, method)?;
+        let outcome = result_or_error(envelope, method);
+        trace(
+            method,
+            &id,
+            outcome.as_ref().ok(),
+            outcome.as_ref().err(),
+            started.elapsed(),
+        );
+        outcome
+    }
+
+    fn request_id(&self) -> String {
+        format!(
+            "herdr-agent-team:{}",
+            self.next_id.fetch_add(1, Ordering::Relaxed)
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum StreamItem {
+    Snapshot(SessionSnapshot),
+    Event(SubscriptionEvent),
+}
+
+pub enum Backend {
+    Cli(HerdrClient),
+    Socket(SocketClient),
+}
+
+/// Socket-aware collector adapters preserve durable run/inbox truth. A socket
+/// snapshot is used as the fast freshness probe; clean fallback retains the
+/// exact existing collector verdict when the socket disappears.
+pub struct SocketGodCollector<C, G> {
+    pub socket: SocketClient<C>,
+    pub fallback: G,
+}
+impl<C: HerdrApi, G: GodCollector> GodCollector for SocketGodCollector<C, G> {
+    fn collect(&self) -> Result<GodSnapshot, GodCliError> {
+        let _ = self.socket.snapshot();
+        self.fallback.collect()
+    }
+    fn wait_for_change(&self, timeout: Duration) {
+        if self.socket.wait_for_team_change(timeout).is_err() {
+            self.fallback.wait_for_change(timeout);
+        }
+    }
+}
+pub struct SocketBoardCollector<C, B> {
+    pub socket: SocketClient<C>,
+    pub fallback: B,
+}
+impl<C: HerdrApi, B: BoardCollector> BoardCollector for SocketBoardCollector<C, B> {
+    fn collect(&self) -> Result<BoardSnapshot, BoardError> {
+        let _ = self.socket.snapshot();
+        self.fallback.collect()
+    }
+}
+
+macro_rules! delegate {
+    ($self:ident.$method:ident($($arg:expr),*)) => { match $self { Backend::Cli(c) => c.$method($($arg),*), Backend::Socket(c) => c.$method($($arg),*) } };
+}
+
+impl HerdrApi for Backend {
+    fn workspace_create(&self, c: &Path, l: &str) -> Result<WorkspaceRef, HerdrError> {
+        delegate!(self.workspace_create(c, l))
+    }
+    fn workspace_close(&self, w: &str) -> Result<(), HerdrError> {
+        delegate!(self.workspace_close(w))
+    }
+    fn worktree_create(&self, r: &Path, b: &str) -> Result<WorktreeRef, HerdrError> {
+        delegate!(self.worktree_create(r, b))
+    }
+    fn worktree_remove(&self, p: &Path) -> Result<(), HerdrError> {
+        delegate!(self.worktree_remove(p))
+    }
+    fn pane_run(&self, p: &str, i: &str) -> Result<(), HerdrError> {
+        delegate!(self.pane_run(p, i))
+    }
+    fn pane_get(&self, p: &str) -> Result<PaneInfo, HerdrError> {
+        delegate!(self.pane_get(p))
+    }
+    fn agent_list(&self) -> Result<Vec<AgentInfo>, HerdrError> {
+        delegate!(self.agent_list())
+    }
+    fn agent_wait(&self, p: &str, s: &str, t: Duration) -> Result<WaitOutcome, HerdrError> {
+        delegate!(self.agent_wait(p, s, t))
+    }
+}
+
+impl<C: HerdrApi> HerdrApi for SocketClient<C> {
+    fn workspace_create(&self, c: &Path, l: &str) -> Result<WorkspaceRef, HerdrError> {
+        self.fallback.workspace_create(c, l)
+    }
+    fn workspace_close(&self, w: &str) -> Result<(), HerdrError> {
+        self.fallback.workspace_close(w)
+    }
+    fn worktree_create(&self, r: &Path, b: &str) -> Result<WorktreeRef, HerdrError> {
+        self.fallback.worktree_create(r, b)
+    }
+    fn worktree_remove(&self, p: &Path) -> Result<(), HerdrError> {
+        self.fallback.worktree_remove(p)
+    }
+    fn pane_split(&self, w: &str, c: &Path) -> Result<PaneInfo, HerdrError> {
+        self.fallback.pane_split(w, c)
+    }
+    fn pane_run(&self, p: &str, i: &str) -> Result<(), HerdrError> {
+        self.fallback.pane_run(p, i)
+    }
+    fn pane_read(&self, p: &str) -> Result<String, HerdrError> {
+        self.fallback.pane_read(p)
+    }
+    fn pane_rename(&self, p: &str, t: &str) -> Result<(), HerdrError> {
+        self.fallback.pane_rename(p, t)
+    }
+    fn agent_wait(&self, p: &str, s: &str, t: Duration) -> Result<WaitOutcome, HerdrError> {
+        self.fallback.agent_wait(p, s, t)
+    }
+    fn agent_list(&self) -> Result<Vec<AgentInfo>, HerdrError> {
+        self.fallback.agent_list()
+    }
+    fn pane_get(&self, p: &str) -> Result<PaneInfo, HerdrError> {
+        self.fallback.pane_get(p)
+    }
+    fn api_schema(&self) -> Result<String, HerdrError> {
+        self.fallback.api_schema()
+    }
+    fn pane_report_metadata(&self, p: &str, u: &MetadataUpdate) -> Result<(), HerdrError> {
+        self.fallback.pane_report_metadata(p, u)
+    }
+    fn notification_show(&self, t: &str, b: &str, s: &str) -> Result<(), HerdrError> {
+        self.fallback.notification_show(t, b, s)
+    }
+}
+
+#[cfg(unix)]
+fn connect(path: &Path) -> Result<UnixStream, HerdrError> {
+    UnixStream::connect(path).map_err(|e| invalid_msg("socket connect", &e.to_string()))
+}
+#[cfg(not(unix))]
+fn connect(_: &Path) -> Result<std::fs::File, HerdrError> {
+    Err(invalid_msg(
+        "socket connect",
+        "public socket backend is unavailable on this platform",
+    ))
+}
+fn write_request<W: Write>(w: &mut W, r: &Request<'_>) -> Result<(), HerdrError> {
+    serde_json::to_writer(&mut *w, r).map_err(|e| invalid("request", e))?;
+    w.write_all(b"\n").map_err(|e| invalid("request", e))?;
+    w.flush().map_err(|e| invalid("request", e))
+}
+fn read_envelope<R: BufRead>(r: &mut R, max: usize, m: &str) -> Result<Envelope, HerdrError> {
+    let v = read_value_optional(r, max, m)?.ok_or_else(|| invalid_msg(m, "empty response"))?;
+    serde_json::from_value(v).map_err(|e| invalid(m, e))
+}
+fn read_value_optional<R: BufRead>(
+    r: &mut R,
+    max: usize,
+    m: &str,
+) -> Result<Option<Value>, HerdrError> {
+    let mut bytes = Vec::new();
+    let mut limited = std::io::Read::take(std::io::Read::by_ref(r), (max + 1) as u64);
+    let n = limited
+        .read_until(b'\n', &mut bytes)
+        .map_err(|e| invalid(m, e))?;
+    if n == 0 {
+        return Ok(None);
+    }
+    if bytes.len() > max {
+        return Err(invalid_msg(m, &format!("frame exceeds {max} byte limit")));
+    }
+    if !bytes.ends_with(b"\n") {
+        return Err(invalid_msg(m, "malformed frame: missing newline"));
+    }
+    serde_json::from_slice(&bytes)
+        .map(Some)
+        .map_err(|e| invalid(m, e))
+}
+fn check_id(expected: &str, actual: &str, m: &str) -> Result<(), HerdrError> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(invalid_msg(
+            m,
+            &format!("response id mismatch: expected {expected}, got {actual}"),
+        ))
+    }
+}
+fn result_or_error(e: Envelope, m: &str) -> Result<Value, HerdrError> {
+    match (e.result, e.error) {
+        (Some(v), None) => Ok(v),
+        (None, Some(e)) => Err(invalid_msg(m, &format!("{}: {}", e.code, e.message))),
+        _ => Err(invalid_msg(
+            m,
+            "response must contain exactly one of result or error",
+        )),
+    }
+}
+fn invalid(m: &str, e: impl std::fmt::Display) -> HerdrError {
+    invalid_msg(m, &e.to_string())
+}
+fn invalid_msg(m: &str, s: &str) -> HerdrError {
+    HerdrError::InvalidResponse {
+        argv: format!("public socket {m}"),
+        message: s.into(),
+    }
+}
+fn validate_schema_baseline() -> Result<(), HerdrError> {
+    for required in [
+        "\"const\": \"ping\"",
+        "\"const\": \"session.snapshot\"",
+        "\"const\": \"events.subscribe\"",
+        "\"const\": \"subscription_started\"",
+    ] {
+        if !SCHEMA_BASELINE.contains(required) {
+            return Err(invalid_msg(
+                "schema baseline",
+                &format!("protocol-16 snapshot lacks {required}"),
+            ));
+        }
+    }
+    Ok(())
+}
+fn trace(
+    method: &str,
+    id: &str,
+    result: Option<&Value>,
+    error: Option<&HerdrError>,
+    elapsed: Duration,
+) {
+    let Some(path) = std::env::var_os(TRACE_ENV) else {
+        return;
+    };
+    let result_type = result.and_then(|v| v.get("type")).and_then(Value::as_str);
+    let row = json!({"id":id,"method":method,"result_type":result_type,"error":error.map(ToString::to_string),"latency_ms":elapsed.as_millis()});
+    if let Ok(mut f) = OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(f, "{row}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::god_cli::{GodSnapshot, InboxRow};
+    use crate::herdr::test_support::FakeHerdr;
+    use crate::types::{RunLifecycle, WorkerLifecycle};
+    use std::fs;
+    use std::os::unix::net::UnixListener;
+    use std::thread;
+
+    fn snapshot(id: &str) -> String {
+        format!("{{\"id\":\"{id}\",\"result\":{{\"type\":\"session_snapshot\",\"snapshot\":{{\"version\":\"0.9.0\",\"protocol\":16,\"focused_workspace_id\":null,\"focused_tab_id\":null,\"focused_pane_id\":null,\"workspaces\":[],\"tabs\":[],\"panes\":[],\"layouts\":[],\"agents\":[]}}}}}}\n")
+    }
+
+    fn fake(responses: Vec<String>) -> (PathBuf, thread::JoinHandle<()>) {
+        let path = std::env::temp_dir().join(format!(
+            "hat-socket-{}-{}.sock",
+            std::process::id(),
+            rand_id()
+        ));
+        let _ = fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+        let h = thread::spawn(move || {
+            for response in responses {
+                let (mut s, _) = listener.accept().unwrap();
+                let mut line = String::new();
+                BufReader::new(s.try_clone().unwrap())
+                    .read_line(&mut line)
+                    .unwrap();
+                s.write_all(response.as_bytes()).unwrap();
+            }
+        });
+        (path, h)
+    }
+    fn rand_id() -> u128 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    }
+    fn pong(id: &str, p: u32) -> String {
+        format!("{{\"id\":\"{id}\",\"result\":{{\"type\":\"pong\",\"version\":\"0.9.0\",\"protocol\":{p}}}}}\n")
+    }
+    #[test]
+    fn handshake_accepts_protocol_16() {
+        let (path, h) = fake(vec![pong("herdr-agent-team:0", 16)]);
+        let c = SocketClient::connect(path.clone(), FakeHerdr::default()).unwrap();
+        assert_eq!(
+            c.handshake(),
+            &Handshake {
+                version: "0.9.0".into(),
+                protocol: 16
+            }
+        );
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+    }
+    #[test]
+    fn wrong_protocol_is_clear() {
+        let (path, h) = fake(vec![pong("herdr-agent-team:0", 15)]);
+        let e = SocketClient::connect(path.clone(), FakeHerdr::default())
+            .err()
+            .expect("wrong protocol must fail")
+            .to_string();
+        assert!(e.contains("client supports 16, server reported 15"));
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+    }
+    #[test]
+    fn response_id_mismatch_is_rejected() {
+        let (path, h) = fake(vec![pong("wrong", 16)]);
+        let e = SocketClient::connect(path.clone(), FakeHerdr::default())
+            .err()
+            .expect("wrong id must fail")
+            .to_string();
+        assert!(e.contains("response id mismatch"));
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+    }
+    #[test]
+    fn malformed_frame_is_rejected() {
+        let (path, h) = fake(vec!["not-json\n".into()]);
+        assert!(SocketClient::connect(path.clone(), FakeHerdr::default()).is_err());
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+    }
+    #[test]
+    fn bounded_frame_is_enforced() {
+        let (path, h) = fake(vec![format!(
+            "{}\n",
+            "x".repeat(DEFAULT_MAX_FRAME_BYTES + 1)
+        )]);
+        let e = SocketClient::connect(path.clone(), FakeHerdr::default())
+            .err()
+            .expect("oversize frame must fail")
+            .to_string();
+        assert!(e.contains("frame exceeds"));
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+    }
+    #[test]
+    fn mutations_delegate_to_cli_seam() {
+        let (path, h) = fake(vec![pong("herdr-agent-team:0", 16)]);
+        let fallback = FakeHerdr::default();
+        let c = SocketClient::connect(path.clone(), fallback).unwrap();
+        assert_eq!(
+            c.workspace_create(Path::new("/tmp"), "x")
+                .unwrap()
+                .workspace_id,
+            "workspace-1"
+        );
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn snapshot_subscribe_reconnect_resnapshots() {
+        let (path, h) = fake(vec![
+            pong("herdr-agent-team:0", 16),
+            snapshot("herdr-agent-team:1"),
+            "{\"id\":\"herdr-agent-team:2\",\"result\":{\"type\":\"subscription_started\"}}\n".into(),
+            snapshot("herdr-agent-team:3"),
+            concat!("{\"id\":\"herdr-agent-team:4\",\"result\":{\"type\":\"subscription_started\"}}\n", "{\"event\":\"pane.agent_status_changed\",\"data\":{\"pane_id\":\"p1\",\"workspace_id\":\"w1\",\"agent_status\":\"blocked\"}}\n").into(),
+        ]);
+        let client = SocketClient::connect(path.clone(), FakeHerdr::default()).unwrap();
+        let mut items = Vec::new();
+        client
+            .subscribe_with_reconnect(&[json!({"type":"pane.agent_status_changed"})], 1, |item| {
+                items.push(item)
+            })
+            .unwrap();
+        assert_eq!(
+            items
+                .iter()
+                .filter(|i| matches!(i, StreamItem::Snapshot(_)))
+                .count(),
+            2
+        );
+        assert_eq!(
+            items
+                .iter()
+                .filter(|i| matches!(i, StreamItem::Event(_)))
+                .count(),
+            1
+        );
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn connect_failure_can_cleanly_retain_cli_backend() {
+        let missing = std::env::temp_dir().join(format!("missing-{}.sock", rand_id()));
+        assert!(SocketClient::connect(missing, FakeHerdr::default()).is_err());
+        let fallback = FakeHerdr::default();
+        assert_eq!(
+            fallback
+                .workspace_create(Path::new("/tmp"), "x")
+                .unwrap()
+                .workspace_id,
+            "workspace-1"
+        );
+    }
+
+    #[derive(Clone)]
+    struct FixtureGod(GodSnapshot);
+    impl GodCollector for FixtureGod {
+        fn collect(&self) -> Result<GodSnapshot, GodCliError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[test]
+    fn socket_god_collector_matches_cli_fixture_verdict() {
+        let expected = GodSnapshot {
+            run_dir: PathBuf::from("/run"),
+            lifecycle: RunLifecycle::Active,
+            rows: vec![InboxRow {
+                worker: "m".into(),
+                report_present: false,
+                report_mtime_ms: None,
+                attention: true,
+                read: false,
+                stopped_not_done: false,
+            }],
+            worker_lifecycles: vec![("m".into(), WorkerLifecycle::Running)],
+            statuses: vec![("m".into(), "blocked".into())],
+        };
+        let (path, h) = fake(vec![
+            pong("herdr-agent-team:0", 16),
+            snapshot("herdr-agent-team:1"),
+        ]);
+        let socket = SocketClient::connect(path.clone(), FakeHerdr::default()).unwrap();
+        let cli = FixtureGod(expected.clone());
+        let over_socket = SocketGodCollector {
+            socket,
+            fallback: cli.clone(),
+        };
+        assert_eq!(cli.collect().unwrap(), over_socket.collect().unwrap());
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+    }
+}

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -21,6 +21,9 @@ use std::time::{Duration, Instant};
 
 pub const SUPPORTED_PROTOCOL: u32 = 16;
 pub const DEFAULT_MAX_FRAME_BYTES: usize = 1024 * 1024;
+pub const DEFAULT_IO_TIMEOUT: Duration = Duration::from_millis(100);
+pub const MAX_RECONNECTS: usize = 3;
+const RECONNECT_BACKOFF: Duration = Duration::from_millis(10);
 const BACKEND_ENV: &str = "HERDR_TEAM_BACKEND";
 const TRACE_ENV: &str = "HERDR_TEAM_SOCKET_TRACE";
 const SCHEMA_BASELINE: &str = include_str!("../docs/herdr-api-schema.snapshot.json");
@@ -39,18 +42,66 @@ pub struct SessionSnapshot {
     pub focused_workspace_id: Option<String>,
     pub focused_tab_id: Option<String>,
     pub focused_pane_id: Option<String>,
-    pub workspaces: Vec<Value>,
-    pub tabs: Vec<Value>,
-    pub panes: Vec<Value>,
-    pub layouts: Vec<Value>,
-    pub agents: Vec<Value>,
+    pub workspaces: Vec<SnapshotWorkspace>,
+    pub tabs: Vec<SnapshotTab>,
+    pub panes: Vec<SnapshotPane>,
+    pub layouts: Vec<SnapshotLayout>,
+    pub agents: Vec<SnapshotAgent>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct SubscriptionEvent {
-    pub event: String,
-    pub data: Value,
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct SnapshotWorkspace {
+    pub workspace_id: String,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct SnapshotTab {
+    pub tab_id: String,
+    pub workspace_id: String,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct SnapshotPane {
+    pub pane_id: String,
+    pub terminal_id: String,
+    pub workspace_id: String,
+    pub tab_id: String,
+    pub agent_status: AgentStatus,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct SnapshotLayout {
+    pub workspace_id: String,
+    pub tab_id: String,
+    pub focused_pane_id: String,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct SnapshotAgent {
+    pub terminal_id: String,
+    pub workspace_id: String,
+    pub tab_id: String,
+    pub pane_id: String,
+    pub agent_status: AgentStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentStatus {
+    Idle,
+    Working,
+    Blocked,
+    Done,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "event", content = "data")]
+pub enum SubscriptionEvent {
+    #[serde(rename = "pane.agent_status_changed")]
+    PaneAgentStatusChanged(PaneAgentStatusChanged),
+}
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct PaneAgentStatusChanged {
+    pub pane_id: String,
+    pub workspace_id: String,
+    pub agent_status: AgentStatus,
 }
 
 #[derive(Debug, Deserialize)]
@@ -82,6 +133,7 @@ pub struct SocketClient<C = HerdrClient> {
     socket_path: PathBuf,
     fallback: C,
     max_frame_bytes: usize,
+    io_timeout: Duration,
     next_id: std::sync::Arc<AtomicU64>,
     handshake: Handshake,
 }
@@ -113,11 +165,16 @@ impl SocketClient<HerdrClient> {
 
 impl<C: HerdrApi> SocketClient<C> {
     pub fn connect(socket_path: PathBuf, fallback: C) -> Result<Self, HerdrError> {
-        validate_schema_baseline()?;
+        validate_runtime_schema(&fallback.api_schema()?)?;
+        Self::connect_validated(socket_path, fallback)
+    }
+
+    fn connect_validated(socket_path: PathBuf, fallback: C) -> Result<Self, HerdrError> {
         let mut client = Self {
             socket_path,
             fallback,
             max_frame_bytes: DEFAULT_MAX_FRAME_BYTES,
+            io_timeout: DEFAULT_IO_TIMEOUT,
             next_id: Default::default(),
             handshake: Handshake {
                 version: String::new(),
@@ -157,28 +214,17 @@ impl<C: HerdrApi> SocketClient<C> {
     where
         F: FnMut(StreamItem),
     {
+        let reconnects = reconnects.min(MAX_RECONNECTS);
+        let deadline = Instant::now() + self.io_timeout.saturating_mul((reconnects as u32 + 1) * 3);
         for attempt in 0..=reconnects {
-            on_item(StreamItem::Snapshot(self.snapshot()?));
-            let id = self.request_id();
-            let mut stream = connect(&self.socket_path)?;
-            write_request(
-                &mut stream,
-                &Request {
-                    id: &id,
-                    method: "events.subscribe",
-                    params: json!({"subscriptions": subscriptions}),
-                },
-            )?;
-            let mut reader = BufReader::new(stream);
-            let ack = read_envelope(&mut reader, self.max_frame_bytes, "events.subscribe")?;
-            check_id(&id, &ack.id, "events.subscribe")?;
-            let value = result_or_error(ack, "events.subscribe")?;
-            if value.get("type").and_then(Value::as_str) != Some("subscription_started") {
+            if Instant::now() >= deadline {
                 return Err(invalid_msg(
                     "events.subscribe",
-                    "expected result.type subscription_started",
+                    "reconnect deadline exceeded",
                 ));
             }
+            on_item(StreamItem::Snapshot(self.snapshot()?));
+            let mut reader = self.open_subscription(subscriptions, self.io_timeout)?;
             while let Some(value) =
                 read_value_optional(&mut reader, self.max_frame_bytes, "events.subscribe")?
             {
@@ -190,6 +236,9 @@ impl<C: HerdrApi> SocketClient<C> {
             if attempt == reconnects {
                 return Ok(());
             }
+            std::thread::sleep(
+                RECONNECT_BACKOFF.min(deadline.saturating_duration_since(Instant::now())),
+            );
         }
         Ok(())
     }
@@ -199,31 +248,31 @@ impl<C: HerdrApi> SocketClient<C> {
     /// by `GodCollector`, so this stays one multiplexed server subscription.
     pub fn wait_for_team_change(
         &self,
+        pane_ids: &[String],
         timeout: Duration,
     ) -> Result<Option<SubscriptionEvent>, HerdrError> {
-        let id = self.request_id();
-        let mut stream = connect(&self.socket_path)?;
-        stream
-            .set_read_timeout(Some(timeout))
-            .map_err(|e| invalid("events.subscribe", e))?;
-        write_request(
-            &mut stream,
-            &Request {
-                id: &id,
-                method: "events.subscribe",
-                params: json!({"subscriptions":[{"type":"pane.agent_status_changed"}]}),
-            },
-        )?;
-        let mut reader = BufReader::new(stream);
-        let ack = read_envelope(&mut reader, self.max_frame_bytes, "events.subscribe")?;
-        check_id(&id, &ack.id, "events.subscribe")?;
-        let value = result_or_error(ack, "events.subscribe")?;
-        if value.get("type").and_then(Value::as_str) != Some("subscription_started") {
-            return Err(invalid_msg(
-                "events.subscribe",
-                "expected result.type subscription_started",
-            ));
-        }
+        let subscriptions = pane_ids
+            .iter()
+            .map(|pane_id| json!({"type":"pane.agent_status_changed","pane_id":pane_id}))
+            .collect::<Vec<_>>();
+        self.read_one_event(&subscriptions, timeout)
+    }
+
+    pub fn wait_for_change(
+        &self,
+        subscriptions: &[Value],
+        timeout: Duration,
+    ) -> Result<bool, HerdrError> {
+        self.read_one_event(subscriptions, timeout)
+            .map(|event| event.is_some())
+    }
+
+    fn read_one_event(
+        &self,
+        subscriptions: &[Value],
+        timeout: Duration,
+    ) -> Result<Option<SubscriptionEvent>, HerdrError> {
+        let mut reader = self.open_subscription(subscriptions, timeout)?;
         read_value_optional(&mut reader, self.max_frame_bytes, "events.subscribe")?
             .map(|value| {
                 serde_json::from_value(value).map_err(|e| invalid("events.subscribe event", e))
@@ -258,7 +307,7 @@ impl<C: HerdrApi> SocketClient<C> {
     fn rpc(&self, method: &str, params: Value) -> Result<Value, HerdrError> {
         let started = Instant::now();
         let id = self.request_id();
-        let mut stream = connect(&self.socket_path)?;
+        let mut stream = self.open_stream(self.io_timeout)?;
         write_request(
             &mut stream,
             &Request {
@@ -286,6 +335,45 @@ impl<C: HerdrApi> SocketClient<C> {
             self.next_id.fetch_add(1, Ordering::Relaxed)
         )
     }
+
+    fn open_stream(&self, timeout: Duration) -> Result<UnixStream, HerdrError> {
+        let stream = connect(&self.socket_path)?;
+        stream
+            .set_read_timeout(Some(timeout))
+            .map_err(|e| invalid("socket timeout", e))?;
+        stream
+            .set_write_timeout(Some(timeout))
+            .map_err(|e| invalid("socket timeout", e))?;
+        Ok(stream)
+    }
+
+    fn open_subscription(
+        &self,
+        subscriptions: &[Value],
+        timeout: Duration,
+    ) -> Result<BufReader<UnixStream>, HerdrError> {
+        let id = self.request_id();
+        let mut stream = self.open_stream(timeout)?;
+        write_request(
+            &mut stream,
+            &Request {
+                id: &id,
+                method: "events.subscribe",
+                params: json!({"subscriptions": subscriptions}),
+            },
+        )?;
+        let mut reader = BufReader::new(stream);
+        let ack = read_envelope(&mut reader, self.max_frame_bytes, "events.subscribe")?;
+        check_id(&id, &ack.id, "events.subscribe")?;
+        let value = result_or_error(ack, "events.subscribe")?;
+        #[derive(Deserialize)]
+        #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+        enum Ack {
+            SubscriptionStarted {},
+        }
+        serde_json::from_value::<Ack>(value).map_err(|e| invalid("events.subscribe ack", e))?;
+        Ok(reader)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -312,9 +400,20 @@ impl<C: HerdrApi, G: GodCollector> GodCollector for SocketGodCollector<C, G> {
         self.fallback.collect()
     }
     fn wait_for_change(&self, timeout: Duration) {
-        if self.socket.wait_for_team_change(timeout).is_err() {
+        let subscriptions = self
+            .fallback
+            .subscription_panes()
+            .into_iter()
+            .map(|pane_id| json!({"type":"pane.agent_status_changed","pane_id":pane_id}))
+            .collect::<Vec<_>>();
+        if subscriptions.is_empty() {
             self.fallback.wait_for_change(timeout);
+        } else {
+            let _ = self.socket.wait_for_change(&subscriptions, timeout);
         }
+    }
+    fn subscription_panes(&self) -> Vec<String> {
+        self.fallback.subscription_panes()
     }
 }
 pub struct SocketBoardCollector<C, B> {
@@ -325,6 +424,20 @@ impl<C: HerdrApi, B: BoardCollector> BoardCollector for SocketBoardCollector<C, 
     fn collect(&self) -> Result<BoardSnapshot, BoardError> {
         let _ = self.socket.snapshot();
         self.fallback.collect()
+    }
+    fn wait_for_change(&self, timeout: Duration) -> bool {
+        let subscriptions = self
+            .fallback
+            .subscription_panes()
+            .into_iter()
+            .map(|pane_id| json!({"type":"pane.agent_status_changed","pane_id":pane_id}))
+            .collect::<Vec<_>>();
+        self.socket
+            .wait_for_change(&subscriptions, timeout)
+            .unwrap_or(true)
+    }
+    fn subscription_panes(&self) -> Vec<String> {
+        self.fallback.subscription_panes()
     }
 }
 
@@ -476,19 +589,22 @@ fn invalid_msg(m: &str, s: &str) -> HerdrError {
         message: s.into(),
     }
 }
-fn validate_schema_baseline() -> Result<(), HerdrError> {
-    for required in [
-        "\"const\": \"ping\"",
-        "\"const\": \"session.snapshot\"",
-        "\"const\": \"events.subscribe\"",
-        "\"const\": \"subscription_started\"",
-    ] {
-        if !SCHEMA_BASELINE.contains(required) {
-            return Err(invalid_msg(
-                "schema baseline",
-                &format!("protocol-16 snapshot lacks {required}"),
-            ));
-        }
+fn validate_runtime_schema(runtime: &str) -> Result<(), HerdrError> {
+    let baseline: Value =
+        serde_json::from_str(SCHEMA_BASELINE).map_err(|e| invalid("schema baseline", e))?;
+    let runtime: Value = serde_json::from_str(runtime).map_err(|e| invalid("runtime schema", e))?;
+    let protocol = runtime.get("protocol").and_then(Value::as_u64);
+    if protocol != Some(u64::from(SUPPORTED_PROTOCOL)) {
+        return Err(invalid_msg(
+            "runtime schema",
+            &format!("expected protocol {SUPPORTED_PROTOCOL}, got {protocol:?}"),
+        ));
+    }
+    if runtime != baseline {
+        return Err(invalid_msg(
+            "runtime schema",
+            "installed Herdr schema differs from checked-in protocol-16 snapshot",
+        ));
     }
     Ok(())
 }
@@ -503,7 +619,11 @@ fn trace(
         return;
     };
     let result_type = result.and_then(|v| v.get("type")).and_then(Value::as_str);
-    let row = json!({"id":id,"method":method,"result_type":result_type,"error":error.map(ToString::to_string),"latency_ms":elapsed.as_millis()});
+    let error_code = error.map(|_| "transport_or_protocol_error");
+    let row = json!({"id":id,"method":method,"result_type":result_type,"error_code":error_code,"latency_ms":elapsed.as_millis()});
+    write_trace(Path::new(&path), &row);
+}
+fn write_trace(path: &Path, row: &Value) {
     if let Ok(mut f) = OpenOptions::new().create(true).append(true).open(path) {
         let _ = writeln!(f, "{row}");
     }
@@ -512,6 +632,7 @@ fn trace(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::board::{BoardSnapshot, BoardWorker};
     use crate::god_cli::{GodSnapshot, InboxRow};
     use crate::herdr::test_support::FakeHerdr;
     use crate::types::{RunLifecycle, WorkerLifecycle};
@@ -543,6 +664,59 @@ mod tests {
         });
         (path, h)
     }
+    fn recording_fake(
+        responses: Vec<String>,
+    ) -> (
+        PathBuf,
+        thread::JoinHandle<()>,
+        std::sync::Arc<std::sync::Mutex<Vec<Value>>>,
+    ) {
+        let path = std::env::temp_dir().join(format!(
+            "hat-recording-{}-{}.sock",
+            std::process::id(),
+            rand_id()
+        ));
+        let _ = fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+        let requests = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = requests.clone();
+        let h = thread::spawn(move || {
+            for response in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut line = String::new();
+                BufReader::new(stream.try_clone().unwrap())
+                    .read_line(&mut line)
+                    .unwrap();
+                captured
+                    .lock()
+                    .unwrap()
+                    .push(serde_json::from_str(&line).unwrap());
+                stream.write_all(response.as_bytes()).unwrap();
+            }
+        });
+        (path, h, requests)
+    }
+    fn silent_fake(hold: Duration, partial: bool) -> (PathBuf, thread::JoinHandle<()>) {
+        let path = std::env::temp_dir().join(format!(
+            "hat-silent-{}-{}.sock",
+            std::process::id(),
+            rand_id()
+        ));
+        let _ = fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+        let h = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = String::new();
+            BufReader::new(stream.try_clone().unwrap())
+                .read_line(&mut request)
+                .unwrap();
+            if partial {
+                stream.write_all(b"{\"id\":\"partial").unwrap();
+            }
+            thread::sleep(hold);
+        });
+        (path, h)
+    }
     fn rand_id() -> u128 {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -555,7 +729,7 @@ mod tests {
     #[test]
     fn handshake_accepts_protocol_16() {
         let (path, h) = fake(vec![pong("herdr-agent-team:0", 16)]);
-        let c = SocketClient::connect(path.clone(), FakeHerdr::default()).unwrap();
+        let c = SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
         assert_eq!(
             c.handshake(),
             &Handshake {
@@ -569,7 +743,7 @@ mod tests {
     #[test]
     fn wrong_protocol_is_clear() {
         let (path, h) = fake(vec![pong("herdr-agent-team:0", 15)]);
-        let e = SocketClient::connect(path.clone(), FakeHerdr::default())
+        let e = SocketClient::connect_validated(path.clone(), FakeHerdr::default())
             .err()
             .expect("wrong protocol must fail")
             .to_string();
@@ -580,7 +754,7 @@ mod tests {
     #[test]
     fn response_id_mismatch_is_rejected() {
         let (path, h) = fake(vec![pong("wrong", 16)]);
-        let e = SocketClient::connect(path.clone(), FakeHerdr::default())
+        let e = SocketClient::connect_validated(path.clone(), FakeHerdr::default())
             .err()
             .expect("wrong id must fail")
             .to_string();
@@ -591,7 +765,7 @@ mod tests {
     #[test]
     fn malformed_frame_is_rejected() {
         let (path, h) = fake(vec!["not-json\n".into()]);
-        assert!(SocketClient::connect(path.clone(), FakeHerdr::default()).is_err());
+        assert!(SocketClient::connect_validated(path.clone(), FakeHerdr::default()).is_err());
         h.join().unwrap();
         let _ = fs::remove_file(path);
     }
@@ -601,7 +775,7 @@ mod tests {
             "{}\n",
             "x".repeat(DEFAULT_MAX_FRAME_BYTES + 1)
         )]);
-        let e = SocketClient::connect(path.clone(), FakeHerdr::default())
+        let e = SocketClient::connect_validated(path.clone(), FakeHerdr::default())
             .err()
             .expect("oversize frame must fail")
             .to_string();
@@ -613,7 +787,7 @@ mod tests {
     fn mutations_delegate_to_cli_seam() {
         let (path, h) = fake(vec![pong("herdr-agent-team:0", 16)]);
         let fallback = FakeHerdr::default();
-        let c = SocketClient::connect(path.clone(), fallback).unwrap();
+        let c = SocketClient::connect_validated(path.clone(), fallback).unwrap();
         assert_eq!(
             c.workspace_create(Path::new("/tmp"), "x")
                 .unwrap()
@@ -633,7 +807,7 @@ mod tests {
             snapshot("herdr-agent-team:3"),
             concat!("{\"id\":\"herdr-agent-team:4\",\"result\":{\"type\":\"subscription_started\"}}\n", "{\"event\":\"pane.agent_status_changed\",\"data\":{\"pane_id\":\"p1\",\"workspace_id\":\"w1\",\"agent_status\":\"blocked\"}}\n").into(),
         ]);
-        let client = SocketClient::connect(path.clone(), FakeHerdr::default()).unwrap();
+        let client = SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
         let mut items = Vec::new();
         client
             .subscribe_with_reconnect(&[json!({"type":"pane.agent_status_changed"})], 1, |item| {
@@ -661,7 +835,7 @@ mod tests {
     #[test]
     fn connect_failure_can_cleanly_retain_cli_backend() {
         let missing = std::env::temp_dir().join(format!("missing-{}.sock", rand_id()));
-        assert!(SocketClient::connect(missing, FakeHerdr::default()).is_err());
+        assert!(SocketClient::connect_validated(missing, FakeHerdr::default()).is_err());
         let fallback = FakeHerdr::default();
         assert_eq!(
             fallback
@@ -670,6 +844,16 @@ mod tests {
                 .workspace_id,
             "workspace-1"
         );
+    }
+
+    #[test]
+    fn silent_partial_peer_is_bounded() {
+        let (path, h) = silent_fake(Duration::from_millis(300), true);
+        let started = Instant::now();
+        assert!(SocketClient::connect_validated(path.clone(), FakeHerdr::default()).is_err());
+        assert!(started.elapsed() < Duration::from_millis(150));
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
     }
 
     #[derive(Clone)]
@@ -700,7 +884,7 @@ mod tests {
             pong("herdr-agent-team:0", 16),
             snapshot("herdr-agent-team:1"),
         ]);
-        let socket = SocketClient::connect(path.clone(), FakeHerdr::default()).unwrap();
+        let socket = SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
         let cli = FixtureGod(expected.clone());
         let over_socket = SocketGodCollector {
             socket,
@@ -708,6 +892,145 @@ mod tests {
         };
         assert_eq!(cli.collect().unwrap(), over_socket.collect().unwrap());
         h.join().unwrap();
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn reconnect_attempts_are_internally_capped() {
+        let mut responses = vec![pong("herdr-agent-team:0", 16)];
+        for attempt in 0..=MAX_RECONNECTS {
+            responses.push(snapshot(&format!("herdr-agent-team:{}", attempt * 2 + 1)));
+            responses.push(format!("{{\"id\":\"herdr-agent-team:{}\",\"result\":{{\"type\":\"subscription_started\"}}}}\n", attempt * 2 + 2));
+        }
+        let (path, h) = fake(responses);
+        let client = SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
+        let mut snapshots = 0;
+        client
+            .subscribe_with_reconnect(
+                &[json!({"type":"pane.agent_status_changed"})],
+                usize::MAX,
+                |item| {
+                    if matches!(item, StreamItem::Snapshot(_)) {
+                        snapshots += 1;
+                    }
+                },
+            )
+            .unwrap();
+        assert_eq!(snapshots, MAX_RECONNECTS + 1);
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn typed_snapshot_and_event_payloads_reject_missing_fields() {
+        let malformed_snapshot = "{\"id\":\"herdr-agent-team:1\",\"result\":{\"type\":\"session_snapshot\",\"snapshot\":{\"version\":\"0.9.0\",\"protocol\":16,\"focused_workspace_id\":null,\"focused_tab_id\":null,\"focused_pane_id\":null,\"workspaces\":[],\"tabs\":[],\"panes\":[{\"pane_id\":\"p1\"}],\"layouts\":[],\"agents\":[]}}}\n";
+        let (path, h) = fake(vec![
+            pong("herdr-agent-team:0", 16),
+            malformed_snapshot.into(),
+        ]);
+        let client = SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
+        assert!(client
+            .snapshot()
+            .unwrap_err()
+            .to_string()
+            .contains("missing field"));
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+
+        let event = "{\"id\":\"herdr-agent-team:1\",\"result\":{\"type\":\"subscription_started\"}}\n{\"event\":\"pane.agent_status_changed\",\"data\":{\"pane_id\":\"p1\"}}\n";
+        let (path, h) = fake(vec![pong("herdr-agent-team:0", 16), event.into()]);
+        let client = SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
+        assert!(client
+            .wait_for_team_change(&["p1".into()], Duration::from_millis(50))
+            .unwrap_err()
+            .to_string()
+            .contains("missing field"));
+        h.join().unwrap();
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn trace_never_serializes_untrusted_error_text() {
+        let path = std::env::temp_dir().join(format!("hat-trace-{}.jsonl", rand_id()));
+        let error = invalid_msg("rpc", "SECRET prompt contents");
+        let row = json!({"id":"r1","method":"pane.run","result_type":null,"error_code":if Some(&error).is_some(){Some("transport_or_protocol_error")}else{None},"latency_ms":1});
+        write_trace(&path, &row);
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(!contents.contains("SECRET"));
+        assert!(!contents.contains("prompt contents"));
+        assert!(contents.contains("transport_or_protocol_error"));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn runtime_schema_must_exactly_match_checked_in_protocol_16() {
+        assert!(validate_runtime_schema(SCHEMA_BASELINE).is_ok());
+        let drifted = SCHEMA_BASELINE.replacen("\"protocol\": 16", "\"protocol\": 17", 1);
+        assert!(validate_runtime_schema(&drifted)
+            .unwrap_err()
+            .to_string()
+            .contains("expected protocol 16"));
+        let drifted = SCHEMA_BASELINE.replacen("\"schema_version\": 1", "\"schema_version\": 2", 1);
+        assert!(validate_runtime_schema(&drifted)
+            .unwrap_err()
+            .to_string()
+            .contains("differs"));
+    }
+
+    #[derive(Clone)]
+    struct FixtureBoard(BoardSnapshot);
+    impl BoardCollector for FixtureBoard {
+        fn collect(&self) -> Result<BoardSnapshot, BoardError> {
+            Ok(self.0.clone())
+        }
+        fn subscription_panes(&self) -> Vec<String> {
+            vec!["p1".into()]
+        }
+    }
+
+    #[test]
+    fn board_bootstraps_snapshot_then_uses_typed_subscription_without_replacing_durable_truth() {
+        let event = concat!("{\"id\":\"herdr-agent-team:2\",\"result\":{\"type\":\"subscription_started\"}}\n", "{\"event\":\"pane.agent_status_changed\",\"data\":{\"pane_id\":\"p1\",\"workspace_id\":\"w1\",\"agent_status\":\"blocked\"}}\n");
+        let (path, h, requests) = recording_fake(vec![
+            pong("herdr-agent-team:0", 16),
+            snapshot("herdr-agent-team:1"),
+            event.into(),
+        ]);
+        let socket = SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
+        let durable = BoardSnapshot {
+            team: "wave8".into(),
+            run_dir: "/run".into(),
+            lifecycle: "active".into(),
+            workers: vec![BoardWorker {
+                name: "m".into(),
+                lifecycle: WorkerLifecycle::Running,
+                pane_id: Some("p1".into()),
+                task: None,
+                report: None,
+            }],
+            mailbox_events: 0,
+        };
+        let collector = SocketBoardCollector {
+            socket,
+            fallback: FixtureBoard(durable.clone()),
+        };
+        assert_eq!(collector.collect().unwrap(), durable);
+        assert!(collector.wait_for_change(Duration::from_millis(50)));
+        h.join().unwrap();
+        let methods = requests
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|request| request["method"].as_str().unwrap().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            methods,
+            vec!["ping", "session.snapshot", "events.subscribe"]
+        );
+        assert_eq!(
+            requests.lock().unwrap()[2]["params"]["subscriptions"][0]["pane_id"],
+            "p1"
+        );
         let _ = fs::remove_file(path);
     }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -18,7 +18,7 @@ pub const SUPPORTED_PROTOCOL: u32 = 16;
 pub const DEFAULT_MAX_FRAME_BYTES: usize = 1024 * 1024;
 pub const DEFAULT_IO_TIMEOUT: Duration = Duration::from_millis(100);
 pub const MAX_RECONNECTS: usize = 3;
-const RECONNECT_BACKOFF: Duration = Duration::from_millis(10);
+pub(crate) const RECONNECT_BACKOFF: Duration = Duration::from_millis(10);
 const BACKEND_ENV: &str = "HERDR_TEAM_BACKEND";
 const TRACE_ENV: &str = "HERDR_TEAM_SOCKET_TRACE";
 const SCHEMA_BASELINE: &str = include_str!("../docs/herdr-api-schema.snapshot.json");
@@ -1068,5 +1068,138 @@ mod tests {
         assert!(!source.contains(&["crate", "::god_cli"].concat()));
         assert!(!source.contains(&["impl Board", "Collector"].concat()));
         assert!(!source.contains(&["impl God", "Collector"].concat()));
+    }
+
+    #[test]
+    fn failed_resnapshot_never_allows_replacement_subscription() {
+        let malformed_snapshot="{\"id\":\"herdr-agent-team:3\",\"result\":{\"type\":\"session_snapshot\",\"snapshot\":{}}}\n";
+        let replacement="{\"id\":\"herdr-agent-team:4\",\"result\":{\"type\":\"subscription_started\"}}\n{\"event\":\"pane.agent_status_changed\",\"data\":{\"pane_id\":\"p1\",\"workspace_id\":\"w1\",\"agent_status\":\"blocked\"}}\n";
+        let (path, h, requests) = recording_fake(vec![
+            pong("herdr-agent-team:0", 16),
+            snapshot("herdr-agent-team:1"),
+            "{\"id\":\"herdr-agent-team:2\",\"result\":{\"type\":\"subscription_started\"}}\n"
+                .into(),
+            malformed_snapshot.into(),
+            replacement.into(),
+        ]);
+        let socket = SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
+        let durable = BoardSnapshot {
+            team: "wave8".into(),
+            run_dir: "/run".into(),
+            lifecycle: "active".into(),
+            workers: vec![],
+            mailbox_events: 0,
+        };
+        let collector = SocketBoardCollector::new(socket, FixtureBoard(durable));
+        collector.collect().unwrap();
+        assert!(collector.wait_for_change(Duration::from_millis(10)));
+        thread::sleep(RECONNECT_BACKOFF + Duration::from_millis(2));
+        collector.collect().unwrap();
+        let _ = collector.wait_for_change(Duration::from_millis(10));
+        drop(collector);
+        drop(h);
+        let methods = requests
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|r| r["method"].as_str().unwrap().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            methods,
+            vec![
+                "ping".to_owned(),
+                "session.snapshot".to_owned(),
+                "events.subscribe".to_owned(),
+                "session.snapshot".to_owned()
+            ]
+        );
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn terminal_typed_event_error_never_reconnects() {
+        let malformed_event="{\"id\":\"herdr-agent-team:2\",\"result\":{\"type\":\"subscription_started\"}}\n{\"event\":\"pane.agent_status_changed\",\"data\":{\"pane_id\":\"p1\"}}\n";
+        let (path, h, requests) = recording_fake(vec![
+            pong("herdr-agent-team:0", 16),
+            snapshot("herdr-agent-team:1"),
+            malformed_event.into(),
+            snapshot("herdr-agent-team:3"),
+            "{\"id\":\"herdr-agent-team:4\",\"result\":{\"type\":\"subscription_started\"}}\n"
+                .into(),
+        ]);
+        let socket = SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
+        let durable = BoardSnapshot {
+            team: "wave8".into(),
+            run_dir: "/run".into(),
+            lifecycle: "active".into(),
+            workers: vec![],
+            mailbox_events: 0,
+        };
+        let collector = SocketBoardCollector::new(socket, FixtureBoard(durable));
+        collector.collect().unwrap();
+        assert!(collector.wait_for_change(Duration::from_millis(10)));
+        collector.collect().unwrap();
+        let _ = collector.wait_for_change(Duration::from_millis(10));
+        drop(collector);
+        drop(h);
+        let methods = requests
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|r| r["method"].as_str().unwrap().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            methods,
+            vec![
+                "ping".to_owned(),
+                "session.snapshot".to_owned(),
+                "events.subscribe".to_owned()
+            ]
+        );
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn production_reconnects_are_capped_and_backed_off() {
+        let mut responses = vec![pong("herdr-agent-team:0", 16)];
+        for attempt in 0..6 {
+            responses.push(snapshot(&format!("herdr-agent-team:{}", attempt * 2 + 1)));
+            responses.push(format!("{{\"id\":\"herdr-agent-team:{}\",\"result\":{{\"type\":\"subscription_started\"}}}}\n",attempt*2+2));
+        }
+        let (path, _h, requests) = recording_fake(responses);
+        let socket = SocketClient::connect_validated(path.clone(), FakeHerdr::default()).unwrap();
+        let durable = BoardSnapshot {
+            team: "wave8".into(),
+            run_dir: "/run".into(),
+            lifecycle: "active".into(),
+            workers: vec![],
+            mailbox_events: 0,
+        };
+        let collector = SocketBoardCollector::new(socket, FixtureBoard(durable));
+        let started = Instant::now();
+        for _ in 0..6 {
+            collector.collect().unwrap();
+            let _ = collector.wait_for_change(Duration::from_millis(20));
+        }
+        let subscribe_count = requests
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r["method"] == "events.subscribe")
+            .count();
+        assert!(subscribe_count <= MAX_RECONNECTS + 1);
+        assert!(started.elapsed() >= RECONNECT_BACKOFF * MAX_RECONNECTS as u32);
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn board_and_god_adapters_share_one_lifecycle_controller() {
+        let source = include_str!("socket_backend.rs");
+        assert_eq!(
+            source.matches("struct CollectorSocketController").count(),
+            1
+        );
+        assert_eq!(source.matches("snapshot_pending").count(), 0);
+        assert!(!source.contains("struct CollectorSocketState"));
     }
 }

--- a/src/socket_backend.rs
+++ b/src/socket_backend.rs
@@ -1,0 +1,238 @@
+//! Process-edge adapters for the experimental public-socket transport.
+//!
+//! Socket events only wake durable collectors. Completion and board truth
+//! remain in `run.toml` and the inbox.
+
+use crate::board::{BoardCollector, BoardError, BoardSnapshot};
+use crate::god_cli::{GodCliError, GodCollector, GodSnapshot};
+use crate::herdr::{
+    AgentInfo, HerdrApi, HerdrError, PaneInfo, WaitOutcome, WorkspaceRef, WorktreeRef,
+};
+use crate::metadata::MetadataUpdate;
+use crate::socket::{SocketClient, SubscriptionPoll, SubscriptionStream};
+use serde_json::{json, Value};
+use std::path::Path;
+use std::sync::{Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+struct CollectorSocketState {
+    subscription: Option<SubscriptionStream>,
+    snapshot_pending: bool,
+}
+
+impl Default for CollectorSocketState {
+    fn default() -> Self {
+        Self {
+            subscription: None,
+            snapshot_pending: true,
+        }
+    }
+}
+
+fn subscriptions(panes: Vec<String>) -> Vec<Value> {
+    panes
+        .into_iter()
+        .map(|pane_id| json!({"type":"pane.agent_status_changed","pane_id":pane_id}))
+        .collect()
+}
+
+fn remaining(started: Instant, budget: Duration) -> Duration {
+    budget.saturating_sub(started.elapsed())
+}
+
+fn lock(state: &Mutex<CollectorSocketState>) -> MutexGuard<'_, CollectorSocketState> {
+    state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+pub struct SocketGodCollector<C, G> {
+    socket: SocketClient<C>,
+    fallback: G,
+    state: Mutex<CollectorSocketState>,
+}
+
+impl<C, G> SocketGodCollector<C, G> {
+    pub fn new(socket: SocketClient<C>, fallback: G) -> Self {
+        Self {
+            socket,
+            fallback,
+            state: Mutex::new(CollectorSocketState::default()),
+        }
+    }
+}
+
+impl<C: HerdrApi, G: GodCollector> GodCollector for SocketGodCollector<C, G> {
+    fn collect(&self) -> Result<GodSnapshot, GodCliError> {
+        let mut state = lock(&self.state);
+        if state.snapshot_pending && self.socket.snapshot().is_ok() {
+            state.snapshot_pending = false;
+        }
+        drop(state);
+        self.fallback.collect()
+    }
+
+    fn wait_for_change(&self, timeout: Duration) {
+        let started = Instant::now();
+        let mut state = lock(&self.state);
+        if state.subscription.is_none() {
+            let wanted = subscriptions(self.fallback.subscription_panes());
+            if wanted.is_empty() {
+                drop(state);
+                self.fallback.wait_for_change(remaining(started, timeout));
+                return;
+            }
+            let budget = remaining(started, timeout);
+            if budget.is_zero() {
+                return;
+            }
+            match self.socket.subscribe(&wanted, budget) {
+                Ok(subscription) => state.subscription = Some(subscription),
+                Err(_) => {
+                    state.snapshot_pending = true;
+                    drop(state);
+                    self.fallback.wait_for_change(remaining(started, timeout));
+                    return;
+                }
+            }
+        }
+        let budget = remaining(started, timeout);
+        if budget.is_zero() {
+            return;
+        }
+        let poll = state
+            .subscription
+            .as_mut()
+            .expect("subscription initialized")
+            .poll(budget);
+        if matches!(poll, Ok(SubscriptionPoll::Closed) | Err(_)) {
+            state.subscription = None;
+            state.snapshot_pending = true;
+            drop(state);
+            self.fallback.wait_for_change(remaining(started, timeout));
+        }
+    }
+
+    fn subscription_panes(&self) -> Vec<String> {
+        self.fallback.subscription_panes()
+    }
+}
+
+pub struct SocketBoardCollector<C, B> {
+    socket: SocketClient<C>,
+    fallback: B,
+    state: Mutex<CollectorSocketState>,
+}
+
+impl<C, B> SocketBoardCollector<C, B> {
+    pub fn new(socket: SocketClient<C>, fallback: B) -> Self {
+        Self {
+            socket,
+            fallback,
+            state: Mutex::new(CollectorSocketState::default()),
+        }
+    }
+}
+
+impl<C: HerdrApi, B: BoardCollector> BoardCollector for SocketBoardCollector<C, B> {
+    fn collect(&self) -> Result<BoardSnapshot, BoardError> {
+        let mut state = lock(&self.state);
+        if state.snapshot_pending && self.socket.snapshot().is_ok() {
+            state.snapshot_pending = false;
+        }
+        drop(state);
+        self.fallback.collect()
+    }
+
+    fn wait_for_change(&self, timeout: Duration) -> bool {
+        let started = Instant::now();
+        let mut state = lock(&self.state);
+        if state.subscription.is_none() {
+            let wanted = subscriptions(self.fallback.subscription_panes());
+            if wanted.is_empty() {
+                return false;
+            }
+            let budget = remaining(started, timeout);
+            if budget.is_zero() {
+                return false;
+            }
+            match self.socket.subscribe(&wanted, budget) {
+                Ok(subscription) => state.subscription = Some(subscription),
+                Err(_) => {
+                    state.snapshot_pending = true;
+                    return true;
+                }
+            }
+        }
+        let budget = remaining(started, timeout);
+        if budget.is_zero() {
+            return false;
+        }
+        match state
+            .subscription
+            .as_mut()
+            .expect("subscription initialized")
+            .poll(budget)
+        {
+            Ok(SubscriptionPoll::Event(event)) => {
+                drop(event);
+                true
+            }
+            Ok(SubscriptionPoll::Timeout) => false,
+            Ok(SubscriptionPoll::Closed) | Err(_) => {
+                state.subscription = None;
+                state.snapshot_pending = true;
+                true
+            }
+        }
+    }
+
+    fn subscription_panes(&self) -> Vec<String> {
+        self.fallback.subscription_panes()
+    }
+}
+
+impl<C: HerdrApi> HerdrApi for SocketClient<C> {
+    fn workspace_create(&self, c: &Path, l: &str) -> Result<WorkspaceRef, HerdrError> {
+        self.fallback().workspace_create(c, l)
+    }
+    fn workspace_close(&self, w: &str) -> Result<(), HerdrError> {
+        self.fallback().workspace_close(w)
+    }
+    fn worktree_create(&self, r: &Path, b: &str) -> Result<WorktreeRef, HerdrError> {
+        self.fallback().worktree_create(r, b)
+    }
+    fn worktree_remove(&self, p: &Path) -> Result<(), HerdrError> {
+        self.fallback().worktree_remove(p)
+    }
+    fn pane_split(&self, w: &str, c: &Path) -> Result<PaneInfo, HerdrError> {
+        self.fallback().pane_split(w, c)
+    }
+    fn pane_run(&self, p: &str, i: &str) -> Result<(), HerdrError> {
+        self.fallback().pane_run(p, i)
+    }
+    fn pane_read(&self, p: &str) -> Result<String, HerdrError> {
+        self.fallback().pane_read(p)
+    }
+    fn pane_rename(&self, p: &str, t: &str) -> Result<(), HerdrError> {
+        self.fallback().pane_rename(p, t)
+    }
+    fn agent_wait(&self, p: &str, s: &str, t: Duration) -> Result<WaitOutcome, HerdrError> {
+        self.fallback().agent_wait(p, s, t)
+    }
+    fn agent_list(&self) -> Result<Vec<AgentInfo>, HerdrError> {
+        self.fallback().agent_list()
+    }
+    fn pane_get(&self, p: &str) -> Result<PaneInfo, HerdrError> {
+        self.fallback().pane_get(p)
+    }
+    fn api_schema(&self) -> Result<String, HerdrError> {
+        self.fallback().api_schema()
+    }
+    fn pane_report_metadata(&self, p: &str, u: &MetadataUpdate) -> Result<(), HerdrError> {
+        self.fallback().pane_report_metadata(p, u)
+    }
+    fn notification_show(&self, t: &str, b: &str, s: &str) -> Result<(), HerdrError> {
+        self.fallback().notification_show(t, b, s)
+    }
+}

--- a/src/socket_backend.rs
+++ b/src/socket_backend.rs
@@ -1,7 +1,7 @@
 //! Process-edge adapters for the experimental public-socket transport.
 //!
-//! Socket events only wake durable collectors. Completion and board truth
-//! remain in `run.toml` and the inbox.
+//! One controller owns snapshot/subscription/reconnect lifecycle. Board and
+//! God wrappers only map its outcomes onto their distinct fallback policies.
 
 use crate::board::{BoardCollector, BoardError, BoardSnapshot};
 use crate::god_cli::{GodCliError, GodCollector, GodSnapshot};
@@ -9,24 +9,180 @@ use crate::herdr::{
     AgentInfo, HerdrApi, HerdrError, PaneInfo, WaitOutcome, WorkspaceRef, WorktreeRef,
 };
 use crate::metadata::MetadataUpdate;
-use crate::socket::{SocketClient, SubscriptionPoll, SubscriptionStream};
+use crate::socket::{
+    SocketClient, SubscriptionPoll, SubscriptionStream, DEFAULT_IO_TIMEOUT, MAX_RECONNECTS,
+    RECONNECT_BACKOFF,
+};
 use serde_json::{json, Value};
 use std::path::Path;
 use std::sync::{Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
-struct CollectorSocketState {
-    subscription: Option<SubscriptionStream>,
-    snapshot_pending: bool,
+enum LifecyclePhase {
+    NeedSnapshot,
+    Ready,
+    Subscribed(SubscriptionStream),
+    Terminal,
+    Exhausted,
 }
 
-impl Default for CollectorSocketState {
+struct LifecycleState {
+    phase: LifecyclePhase,
+    reconnect_attempts: usize,
+    reconnect_deadline: Option<Instant>,
+    retry_not_before: Option<Instant>,
+}
+
+impl Default for LifecycleState {
     fn default() -> Self {
         Self {
-            subscription: None,
-            snapshot_pending: true,
+            phase: LifecyclePhase::NeedSnapshot,
+            reconnect_attempts: 0,
+            reconnect_deadline: None,
+            retry_not_before: None,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ControllerPoll {
+    Event,
+    Timeout,
+    ReconnectPending,
+    Terminal,
+}
+
+struct CollectorSocketController<C> {
+    socket: SocketClient<C>,
+    state: Mutex<LifecycleState>,
+}
+
+impl<C: HerdrApi> CollectorSocketController<C> {
+    fn new(socket: SocketClient<C>) -> Self {
+        Self {
+            socket,
+            state: Mutex::new(LifecycleState::default()),
+        }
+    }
+
+    fn refresh_snapshot(&self) -> ControllerPoll {
+        let mut state = lock(&self.state);
+        self.ensure_snapshot(&mut state)
+    }
+
+    fn poll(&self, panes: Vec<String>, budget: Duration) -> ControllerPoll {
+        if budget.is_zero() {
+            return ControllerPoll::Timeout;
+        }
+        let started = Instant::now();
+        let mut state = lock(&self.state);
+        match self.ensure_snapshot(&mut state) {
+            ControllerPoll::Timeout => {}
+            other => return other,
+        }
+        if matches!(state.phase, LifecyclePhase::Ready) {
+            let wanted = subscriptions(panes);
+            if wanted.is_empty() {
+                return ControllerPoll::Terminal;
+            }
+            let remaining = remaining(started, budget);
+            if remaining.is_zero() {
+                return ControllerPoll::Timeout;
+            }
+            match self.socket.subscribe(&wanted, remaining) {
+                Ok(subscription) => state.phase = LifecyclePhase::Subscribed(subscription),
+                Err(error) => return self.transition_error(&mut state, error),
+            }
+        }
+        let remaining = remaining(started, budget);
+        if remaining.is_zero() {
+            return ControllerPoll::Timeout;
+        }
+        let result = match &mut state.phase {
+            LifecyclePhase::Subscribed(subscription) => subscription.poll(remaining),
+            LifecyclePhase::Terminal | LifecyclePhase::Exhausted => {
+                return ControllerPoll::Terminal
+            }
+            LifecyclePhase::NeedSnapshot => return ControllerPoll::ReconnectPending,
+            LifecyclePhase::Ready => unreachable!("subscription established above"),
+        };
+        match result {
+            Ok(SubscriptionPoll::Event(event)) => {
+                drop(event);
+                healthy(&mut state);
+                ControllerPoll::Event
+            }
+            Ok(SubscriptionPoll::Timeout) => {
+                healthy(&mut state);
+                ControllerPoll::Timeout
+            }
+            Ok(SubscriptionPoll::Closed) => self.transition_loss(&mut state),
+            Err(error) => self.transition_error(&mut state, error),
+        }
+    }
+
+    fn ensure_snapshot(&self, state: &mut LifecycleState) -> ControllerPoll {
+        match state.phase {
+            LifecyclePhase::Ready | LifecyclePhase::Subscribed(_) => {
+                return ControllerPoll::Timeout
+            }
+            LifecyclePhase::Terminal | LifecyclePhase::Exhausted => {
+                return ControllerPoll::Terminal
+            }
+            LifecyclePhase::NeedSnapshot => {}
+        }
+        let now = Instant::now();
+        if state
+            .reconnect_deadline
+            .is_some_and(|deadline| now >= deadline)
+            || state.reconnect_attempts > MAX_RECONNECTS
+        {
+            state.phase = LifecyclePhase::Exhausted;
+            return ControllerPoll::Terminal;
+        }
+        if state.retry_not_before.is_some_and(|retry| now < retry) {
+            return ControllerPoll::ReconnectPending;
+        }
+        match self.socket.snapshot() {
+            Ok(_) => {
+                state.phase = LifecyclePhase::Ready;
+                state.retry_not_before = None;
+                ControllerPoll::Timeout
+            }
+            Err(error) => self.transition_error(state, error),
+        }
+    }
+
+    fn transition_error(&self, state: &mut LifecycleState, error: HerdrError) -> ControllerPoll {
+        if matches!(error, HerdrError::Transport { .. }) {
+            self.transition_loss(state)
+        } else {
+            state.phase = LifecyclePhase::Terminal;
+            ControllerPoll::Terminal
+        }
+    }
+
+    fn transition_loss(&self, state: &mut LifecycleState) -> ControllerPoll {
+        let now = Instant::now();
+        state.reconnect_attempts += 1;
+        state.reconnect_deadline.get_or_insert_with(|| {
+            now + DEFAULT_IO_TIMEOUT.saturating_mul((MAX_RECONNECTS as u32 + 1) * 3)
+        });
+        if state.reconnect_attempts > MAX_RECONNECTS {
+            state.phase = LifecyclePhase::Exhausted;
+            return ControllerPoll::Terminal;
+        }
+        state.retry_not_before =
+            Some(now + RECONNECT_BACKOFF.saturating_mul(state.reconnect_attempts as u32));
+        state.phase = LifecyclePhase::NeedSnapshot;
+        ControllerPoll::ReconnectPending
+    }
+}
+
+fn healthy(state: &mut LifecycleState) {
+    state.reconnect_attempts = 0;
+    state.reconnect_deadline = None;
+    state.retry_not_before = None;
 }
 
 fn subscriptions(panes: Vec<String>) -> Vec<Value> {
@@ -35,158 +191,79 @@ fn subscriptions(panes: Vec<String>) -> Vec<Value> {
         .map(|pane_id| json!({"type":"pane.agent_status_changed","pane_id":pane_id}))
         .collect()
 }
-
 fn remaining(started: Instant, budget: Duration) -> Duration {
     budget.saturating_sub(started.elapsed())
 }
-
-fn lock(state: &Mutex<CollectorSocketState>) -> MutexGuard<'_, CollectorSocketState> {
+fn lock(state: &Mutex<LifecycleState>) -> MutexGuard<'_, LifecycleState> {
     state
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 pub struct SocketGodCollector<C, G> {
-    socket: SocketClient<C>,
+    controller: CollectorSocketController<C>,
     fallback: G,
-    state: Mutex<CollectorSocketState>,
 }
-
-impl<C, G> SocketGodCollector<C, G> {
+impl<C: HerdrApi, G> SocketGodCollector<C, G> {
     pub fn new(socket: SocketClient<C>, fallback: G) -> Self {
         Self {
-            socket,
+            controller: CollectorSocketController::new(socket),
             fallback,
-            state: Mutex::new(CollectorSocketState::default()),
         }
     }
 }
-
 impl<C: HerdrApi, G: GodCollector> GodCollector for SocketGodCollector<C, G> {
     fn collect(&self) -> Result<GodSnapshot, GodCliError> {
-        let mut state = lock(&self.state);
-        if state.snapshot_pending && self.socket.snapshot().is_ok() {
-            state.snapshot_pending = false;
-        }
-        drop(state);
+        let _ = self.controller.refresh_snapshot();
         self.fallback.collect()
     }
-
     fn wait_for_change(&self, timeout: Duration) {
         let started = Instant::now();
-        let mut state = lock(&self.state);
-        if state.subscription.is_none() {
-            let wanted = subscriptions(self.fallback.subscription_panes());
-            if wanted.is_empty() {
-                drop(state);
-                self.fallback.wait_for_change(remaining(started, timeout));
-                return;
+        match self
+            .controller
+            .poll(self.fallback.subscription_panes(), timeout)
+        {
+            ControllerPoll::Event | ControllerPoll::Timeout => {}
+            ControllerPoll::ReconnectPending | ControllerPoll::Terminal => {
+                self.fallback.wait_for_change(remaining(started, timeout))
             }
-            let budget = remaining(started, timeout);
-            if budget.is_zero() {
-                return;
-            }
-            match self.socket.subscribe(&wanted, budget) {
-                Ok(subscription) => state.subscription = Some(subscription),
-                Err(_) => {
-                    state.snapshot_pending = true;
-                    drop(state);
-                    self.fallback.wait_for_change(remaining(started, timeout));
-                    return;
-                }
-            }
-        }
-        let budget = remaining(started, timeout);
-        if budget.is_zero() {
-            return;
-        }
-        let poll = state
-            .subscription
-            .as_mut()
-            .expect("subscription initialized")
-            .poll(budget);
-        if matches!(poll, Ok(SubscriptionPoll::Closed) | Err(_)) {
-            state.subscription = None;
-            state.snapshot_pending = true;
-            drop(state);
-            self.fallback.wait_for_change(remaining(started, timeout));
         }
     }
-
     fn subscription_panes(&self) -> Vec<String> {
         self.fallback.subscription_panes()
     }
 }
 
 pub struct SocketBoardCollector<C, B> {
-    socket: SocketClient<C>,
+    controller: CollectorSocketController<C>,
     fallback: B,
-    state: Mutex<CollectorSocketState>,
 }
-
-impl<C, B> SocketBoardCollector<C, B> {
+impl<C: HerdrApi, B> SocketBoardCollector<C, B> {
     pub fn new(socket: SocketClient<C>, fallback: B) -> Self {
         Self {
-            socket,
+            controller: CollectorSocketController::new(socket),
             fallback,
-            state: Mutex::new(CollectorSocketState::default()),
         }
     }
 }
-
 impl<C: HerdrApi, B: BoardCollector> BoardCollector for SocketBoardCollector<C, B> {
     fn collect(&self) -> Result<BoardSnapshot, BoardError> {
-        let mut state = lock(&self.state);
-        if state.snapshot_pending && self.socket.snapshot().is_ok() {
-            state.snapshot_pending = false;
-        }
-        drop(state);
+        let _ = self.controller.refresh_snapshot();
         self.fallback.collect()
     }
-
     fn wait_for_change(&self, timeout: Duration) -> bool {
         let started = Instant::now();
-        let mut state = lock(&self.state);
-        if state.subscription.is_none() {
-            let wanted = subscriptions(self.fallback.subscription_panes());
-            if wanted.is_empty() {
-                return false;
-            }
-            let budget = remaining(started, timeout);
-            if budget.is_zero() {
-                return false;
-            }
-            match self.socket.subscribe(&wanted, budget) {
-                Ok(subscription) => state.subscription = Some(subscription),
-                Err(_) => {
-                    state.snapshot_pending = true;
-                    return true;
-                }
-            }
-        }
-        let budget = remaining(started, timeout);
-        if budget.is_zero() {
-            return false;
-        }
-        match state
-            .subscription
-            .as_mut()
-            .expect("subscription initialized")
-            .poll(budget)
+        match self
+            .controller
+            .poll(self.fallback.subscription_panes(), timeout)
         {
-            Ok(SubscriptionPoll::Event(event)) => {
-                drop(event);
-                true
-            }
-            Ok(SubscriptionPoll::Timeout) => false,
-            Ok(SubscriptionPoll::Closed) | Err(_) => {
-                state.subscription = None;
-                state.snapshot_pending = true;
-                true
+            ControllerPoll::Event => true,
+            ControllerPoll::Timeout => false,
+            ControllerPoll::ReconnectPending | ControllerPoll::Terminal => {
+                self.fallback.wait_for_change(remaining(started, timeout))
             }
         }
     }
-
     fn subscription_panes(&self) -> Vec<String> {
         self.fallback.subscription_panes()
     }


### PR DESCRIPTION
## Summary
- add a protocol-16 public NDJSON SocketClient with typed handshake, response validation, frame bounds, reconnect/resnapshot, and redacted tracing
- keep mutations on HerdrClient and cleanly fall back when socket opt-in cannot handshake
- wire board and aggregate team wait collector seams to socket snapshots/events while retaining durable verdict truth
- document selection and fallback semantics

## Verification
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test (168 tests)
- 15 consecutive cargo test runs

Closes #8.